### PR TITLE
Add support for holidays landing on both Monday and Tuesday.

### DIFF
--- a/cal.go
+++ b/cal.go
@@ -167,10 +167,15 @@ func (c *Calendar) IsWorkday(date time.Time) bool {
 		return true
 	}
 
-	if c.Observed == ObservedMonday && day == time.Monday {
+	if (c.Observed == ObservedMonday || c.Observed == ObservedMondayTuesday) && day == time.Monday {
 		sun := date.AddDate(0, 0, -1)
 		sat := date.AddDate(0, 0, -2)
 		return !c.IsHoliday(sat) && !c.IsHoliday(sun)
+	} else if c.Observed == ObservedMondayTuesday && day == time.Tuesday {
+		mon := date.AddDate(0, 0, -1)
+		sun := date.AddDate(0, 0, -2)
+		sat := date.AddDate(0, 0, -3)
+		return !(c.IsHoliday(sat) && c.IsHoliday(sun)) && !(c.IsHoliday(sat) && c.IsHoliday(mon)) && !(c.IsHoliday(sun) && c.IsHoliday(mon))
 	} else if c.Observed == ObservedNearest {
 		if day == time.Friday {
 			sat := date.AddDate(0, 0, 1)
@@ -342,16 +347,16 @@ func (c *Calendar) SubSkipNonWorkdays(start time.Time, d time.Duration) time.Tim
 		for !c.IsWorkday(s) {
 			s = s.Add(day)
 		}
-		
-		if (d >= day*-1){
+
+		if d >= day*-1 {
 			s = s.Add(day)
 			d = d + day
 		} else if d > 0 {
 			s = s.Add(-d)
 			d = 0
 		} else {
-				break
-			}
+			break
+		}
 	}
 	return s
 }

--- a/cal_test.go
+++ b/cal_test.go
@@ -331,6 +331,64 @@ func TestWorkdayMonday(t *testing.T) {
 	}
 }
 
+func TestWorkdayMondayTuesday(t *testing.T) {
+	c := NewCalendar()
+	c.Observed = ObservedMondayTuesday
+	c.AddHoliday(
+		GBChristmasDay,
+		GBBoxingDay,
+	)
+
+	tests := []struct {
+		t    time.Time
+		want bool
+	}{
+		{time.Date(2019, 12, 24, 12, 0, 0, 0, time.UTC), true},  // Tue
+		{time.Date(2019, 12, 25, 12, 0, 0, 0, time.UTC), false}, // Wed
+		{time.Date(2019, 12, 26, 12, 0, 0, 0, time.UTC), false}, // Thu
+		{time.Date(2019, 12, 27, 12, 0, 0, 0, time.UTC), true},  // Fri
+		{time.Date(2019, 12, 28, 12, 0, 0, 0, time.UTC), false}, // Sat
+		{time.Date(2019, 12, 29, 12, 0, 0, 0, time.UTC), false}, // Sun
+
+		{time.Date(2020, 12, 24, 12, 0, 0, 0, time.UTC), true},  // Thu
+		{time.Date(2020, 12, 25, 12, 0, 0, 0, time.UTC), false}, // Fri
+		{time.Date(2020, 12, 26, 12, 0, 0, 0, time.UTC), false}, // Sat
+		{time.Date(2020, 12, 27, 12, 0, 0, 0, time.UTC), false}, // Sun
+		{time.Date(2020, 12, 28, 12, 0, 0, 0, time.UTC), false}, // Mon
+		{time.Date(2020, 12, 29, 12, 0, 0, 0, time.UTC), true},  // Tues
+
+		{time.Date(2021, 12, 24, 12, 0, 0, 0, time.UTC), true},  // Fri
+		{time.Date(2021, 12, 25, 12, 0, 0, 0, time.UTC), false}, // Sat
+		{time.Date(2021, 12, 26, 12, 0, 0, 0, time.UTC), false}, // Sun
+		{time.Date(2021, 12, 27, 12, 0, 0, 0, time.UTC), false}, // Mon
+		{time.Date(2021, 12, 28, 12, 0, 0, 0, time.UTC), false}, // Tues
+		{time.Date(2021, 12, 29, 12, 0, 0, 0, time.UTC), true},  // Wed
+
+		{time.Date(2022, 12, 23, 12, 0, 0, 0, time.UTC), true},  // Fri
+		{time.Date(2022, 12, 24, 12, 0, 0, 0, time.UTC), false}, // Sat
+		{time.Date(2022, 12, 25, 12, 0, 0, 0, time.UTC), false}, // Sun
+		{time.Date(2022, 12, 26, 12, 0, 0, 0, time.UTC), false}, // Mon
+		{time.Date(2022, 12, 27, 12, 0, 0, 0, time.UTC), false}, // Tues
+		{time.Date(2022, 12, 28, 12, 0, 0, 0, time.UTC), true},  // Wed
+		{time.Date(2022, 12, 29, 12, 0, 0, 0, time.UTC), true},  // Thu
+
+		{time.Date(2023, 12, 22, 12, 0, 0, 0, time.UTC), true},  // Fri
+		{time.Date(2023, 12, 23, 12, 0, 0, 0, time.UTC), false}, // Sat
+		{time.Date(2023, 12, 24, 12, 0, 0, 0, time.UTC), false}, // Sun
+		{time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC), false}, // Mon
+		{time.Date(2023, 12, 26, 12, 0, 0, 0, time.UTC), false}, // Tues
+		{time.Date(2023, 12, 27, 12, 0, 0, 0, time.UTC), true},  // Wed
+		{time.Date(2023, 12, 28, 12, 0, 0, 0, time.UTC), true},  // Thu
+	}
+
+	for _, test := range tests {
+		got := c.IsWorkday(test.t)
+		if got != test.want {
+			t.Errorf("got: %t; want: %t (%s)", got, test.want, test.t)
+		}
+	}
+}
+
 func TestWorkdays(t *testing.T) {
 	c := NewCalendar()
 	c.AddHoliday(USNewYear, USMLK)
@@ -587,7 +645,6 @@ func TestAddSkipNonWorkdays(t *testing.T) {
 		})
 	}
 }
-
 
 func TestSubSkipNonWorkdays(t *testing.T) {
 	c := NewCalendar()

--- a/holiday.go
+++ b/holiday.go
@@ -12,9 +12,10 @@ type ObservedRule int
 
 // ObservedRule are the specific ObservedRules
 const (
-	ObservedNearest ObservedRule = iota // nearest weekday (Friday or Monday)
-	ObservedExact                       // the exact day only
-	ObservedMonday                      // Monday always
+	ObservedNearest       ObservedRule = iota // nearest weekday (Friday or Monday)
+	ObservedExact                             // the exact day only
+	ObservedMonday                            // Monday always
+	ObservedMondayTuesday                     // As above, but also accounts for Christmas Day being on a weekend (which pushes Boxing Day to Tuesday)
 )
 
 // HolidayFn calculates the occurrence of a holiday for the given year.


### PR DESCRIPTION
Hi - I noticed that your code didn't support what will happen in the UK in 2021 - where both Christmas Day and Boxing Day land on the weekend which pushes the public holidays to Monday and Tuesday. 2022 will be similar. Here's a PR to solve that.

For reference: https://www.gov.uk/bank-holidays

Many thanks for the great library!

Ben
