### PR TITLE
Support VE day in 2020 for GB holidays

### DIFF
--- a/holiday_defs_gb.go
+++ b/holiday_defs_gb.go
@@ -7,7 +7,7 @@ var (
 	GBNewYear       = NewHolidayFunc(calculateNewYearsHoliday)
 	GBGoodFriday    = GoodFriday
 	GBEasterMonday  = EasterMonday
-	GBEarlyMay      = NewHolidayFloat(time.May, time.Monday, 1)
+	GBEarlyMay      = makeGBEarlyMay()
 	GBSpringHoliday = NewHolidayFloat(time.May, time.Monday, -1)
 	GBSummerHoliday = NewHolidayFloat(time.August, time.Monday, -1)
 	GBChristmasDay  = Christmas
@@ -39,4 +39,19 @@ func calculateNewYearsHoliday(year int, loc *time.Location) (time.Month, int) {
 		day = day.AddDate(0, 0, 1)
 	}
 	return time.January, day.Day()
+}
+
+// Early May holiday in UK is usually 1st Monday in May, but in 2020 this is
+// replaced by VE day on Fri 8th May
+func makeGBEarlyMay() Holiday {
+	hol := NewHolidayFloat(time.May, time.Monday, 1)
+	hol.Func = func(year int, loc *time.Location) (month time.Month, day int) {
+		if year == 2020 {
+			// In 2020 force VE day
+			return time.May, 8
+		}
+		// Else defer to floating holiday calculation
+		return time.May, 0
+	}
+	return hol
 }

--- a/holiday_defs_gb_test.go
+++ b/holiday_defs_gb_test.go
@@ -72,6 +72,46 @@ func TestCalculateNewYearsHoliday(t *testing.T) {
 		t.Errorf("Expected %q to be a holiday but wasn't", i)
 	}
 	if c.IsWorkday(i) {
-		t.Errorf("Did not expect %q to be a holiday", i)
+		t.Errorf("Did not expect %q to be a workday", i)
+	}
+}
+
+func TestEarlyMay(t *testing.T) {
+	type date struct {
+		day   int
+		month time.Month
+		year  int
+	}
+	holidays := map[string]date{
+		"early_may_2019": {
+			day:   6,
+			month: time.May,
+			year:  2019,
+		},
+		"early_may_2020": {
+			day:   8,
+			month: time.May,
+			year:  2020,
+		},
+		"early_may_2021": {
+			day:   3,
+			month: time.May,
+			year:  2021,
+		},
+	}
+
+	for name, holiday := range holidays {
+		t.Run(name, func(t *testing.T) {
+			c := NewCalendar()
+			AddBritishHolidays(c)
+			i := time.Date(holiday.year, holiday.month, holiday.day, 0, 0, 0, 0, time.UTC)
+
+			if !c.IsHoliday(i) {
+				t.Errorf("Expected %q to be a holiday but wasn't", i)
+			}
+			if c.IsWorkday(i) {
+				t.Errorf("Did not expect %q to be a workday", i)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Another from me - 2020 has a special VE day holiday in the UK, replacing the normal early May holiday.

https://www.gov.uk/bank-holidays

Ben

 