### PR TITLE
Add support for office hours

### DIFF
--- a/cal.go
+++ b/cal.go
@@ -7,6 +7,11 @@ import (
 	"time"
 )
 
+const (
+	dayStart = 9
+	dayEnd   = 17
+)
+
 // IsWeekend reports whether the given date falls on a weekend.
 func IsWeekend(date time.Time) bool {
 	day := date.Weekday()
@@ -118,8 +123,8 @@ func NewCalendar() *Calendar {
 	c.workday[time.Wednesday] = true
 	c.workday[time.Thursday] = true
 	c.workday[time.Friday] = true
-	c.dayStart = time.Duration(9 * time.Hour)
-	c.dayEnd = time.Duration(18 * time.Hour)
+	c.dayStart = time.Duration(dayStart * time.Hour)
+	c.dayEnd = time.Duration(dayEnd * time.Hour)
 	return c
 }
 
@@ -344,6 +349,13 @@ func minTime(ts ...time.Time) time.Time {
 	return r
 }
 
+// DailyWorkedTime returns the total time worked per day
+// it makes it easy to compute working times per day
+// allowing calls like c.AddWorkHours(time.Now(), 8 * c.DailyWorkedTime())
+func (c *Calendar) DailyWorkedTime() time.Duration {
+	return c.dayEnd - c.dayStart
+}
+
 // StartWorkTime returns the time at which work starts in the current day
 func (c *Calendar) StartWorkTime(t time.Time) time.Time {
 	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0,
@@ -401,7 +413,7 @@ func (c *Calendar) AddWorkHours(t time.Time, worked time.Duration) time.Time {
 	return t
 }
 
-// SetWorkingHours configures the calendar to override the default 9-18 working hours
+// SetWorkingHours configures the calendar to override the default 9-17 working hours
 func (c *Calendar) SetWorkingHours(start time.Duration, end time.Duration) {
 	if start > end {
 		// This should not really happen, but SetWorkingHours(18*time.Hour, 9*time.Hour) should also mean a 9-18 time range

--- a/cal_test.go
+++ b/cal_test.go
@@ -797,3 +797,104 @@ func TestCalendar_WorkdaysNrInRangeAustralia(t *testing.T) {
 		})
 	}
 }
+
+func TestStartWorkTime(t *testing.T) {
+	c := NewCalendar()
+	got := c.StartWorkTime(time.Date(2020, 04, 15, 01, 20, 0, 0, time.UTC))
+	expected := time.Date(2020, 04, 15, 9, 0, 0, 0, time.UTC)
+	if got != expected {
+		t.Errorf("Calendar.StartWorkTime() = %v, want %v", got, expected)
+	}
+}
+
+func TestEndWorkTime(t *testing.T) {
+	c := NewCalendar()
+	got := c.EndWorkTime(time.Date(2020, 04, 15, 01, 20, 0, 0, time.UTC))
+	expected := time.Date(2020, 04, 15, 18, 0, 0, 0, time.UTC)
+	if got != expected {
+		t.Errorf("Calendar.EndWorkTime() = %v, want %v", got, expected)
+	}
+}
+
+func TestNextWorkStart(t *testing.T) {
+	c := NewCalendar()
+	got := c.NextWorkStart(time.Date(2020, 04, 15, 01, 20, 0, 0, time.UTC))
+	expected := time.Date(2020, 04, 15, 9, 0, 0, 0, time.UTC)
+	if got != expected {
+		t.Errorf("Calendar.NextWorkStart() = %v, want %v", got, expected)
+	}
+	got = c.NextWorkStart(time.Date(2020, 04, 15, 10, 20, 0, 0, time.UTC))
+	expected = time.Date(2020, 04, 16, 9, 0, 0, 0, time.UTC)
+	if got != expected {
+		t.Errorf("Calendar.NextWorkStart() = %v, want %v", got, expected)
+	}
+	got = c.NextWorkStart(time.Date(2020, 04, 15, 21, 20, 0, 0, time.UTC))
+	expected = time.Date(2020, 04, 16, 9, 0, 0, 0, time.UTC)
+	if got != expected {
+		t.Errorf("Calendar.NextWorkStart() = %v, want %v", got, expected)
+	}
+	got = c.NextWorkStart(time.Date(2020, 04, 18, 21, 20, 0, 0, time.UTC))
+	expected = time.Date(2020, 04, 20, 9, 0, 0, 0, time.UTC)
+	if got != expected {
+		t.Errorf("Calendar.NextWorkStart() = %v, want %v", got, expected)
+	}
+}
+
+func TestWorkedHours(t *testing.T) {
+	c := NewCalendar()
+
+	got := c.CountWorkHours(time.Now(), time.Now().Add(7*24*time.Hour))
+	expected := time.Duration(5 * 9 * time.Hour)
+	if got != expected {
+		t.Errorf("Calendar.CountWorkHours() = %v, want %v", got, expected)
+	}
+
+	got = c.CountWorkHours(time.Date(2020, 01, 01, 0, 0, 0, 0, time.UTC), time.Date(2019, 01, 01, 0, 0, 0, 0, time.UTC))
+	expected = time.Duration(9 * 261 * time.Hour)
+	if got != expected {
+		t.Errorf("Calendar.CountWorkHours() = %v, want %v", got, expected)
+	}
+
+	loc, err := time.LoadLocation("Europe/Madrid")
+	if err != nil {
+		t.Errorf("failed to load GMT+1 location: %v", err)
+	}
+
+	got = c.CountWorkHours(time.Date(2020, 4, 15, 10, 0, 0, 0, time.UTC), time.Date(2020, 4, 15, 10, 0, 0, 0, loc))
+	// In april in Spain, there are 2 hours difference with Coordinated Universal Time
+	expected = time.Duration(2 * time.Hour)
+	if got != expected {
+		t.Errorf("Calendar.CountWorkHours() = %v, want %v", got, expected)
+	}
+
+	c.SetWorkingHours(2*time.Hour, 4*time.Hour) // night shift
+	got = c.CountWorkHours(time.Date(2020, 03, 29, 2, 0, 0, 0, loc), time.Date(2020, 03, 29, 4, 0, 0, 0, loc))
+	// 2020/03/29 is the daylight saving date in 2020 for Spain
+	expected = time.Duration(1 * time.Hour)
+	if got != expected {
+		t.Errorf("Calendar.CountWorkHours() = %v, want %v", got, expected)
+	}
+
+}
+
+func TestAddWorkedHours(t *testing.T) {
+	c := NewCalendar()
+
+	got := c.AddWorkHours(time.Date(2020, 04, 15, 3, 0, 0, 0, time.UTC), 10*time.Hour)
+	expected := time.Date(2020, 04, 16, 10, 0, 0, 0, time.UTC)
+	if got != expected {
+		t.Errorf("Calendar.AddWorkHours() = %v, want %v", got, expected)
+	}
+
+	got = c.AddWorkHours(time.Date(2020, 04, 15, 3, 0, 0, 0, time.UTC), 5*9*time.Hour)
+	expected = time.Date(2020, 04, 21, 18, 0, 0, 0, time.UTC)
+	if got != expected {
+		t.Errorf("Calendar.AddWorkHours() = %v, want %v", got, expected)
+	}
+
+	got = c.AddWorkHours(time.Date(2020, 04, 19, 3, 0, 0, 0, time.UTC), 9*time.Hour)
+	expected = time.Date(2020, 04, 20, 18, 0, 0, 0, time.UTC)
+	if got != expected {
+		t.Errorf("Calendar.AddWorkHours() = %v, want %v", got, expected)
+	}
+}

--- a/cal_test.go
+++ b/cal_test.go
@@ -801,7 +801,7 @@ func TestCalendar_WorkdaysNrInRangeAustralia(t *testing.T) {
 func TestStartWorkTime(t *testing.T) {
 	c := NewCalendar()
 	got := c.StartWorkTime(time.Date(2020, 04, 15, 01, 20, 0, 0, time.UTC))
-	expected := time.Date(2020, 04, 15, 9, 0, 0, 0, time.UTC)
+	expected := time.Date(2020, 04, 15, dayStart, 0, 0, 0, time.UTC)
 	if got != expected {
 		t.Errorf("Calendar.StartWorkTime() = %v, want %v", got, expected)
 	}
@@ -810,7 +810,7 @@ func TestStartWorkTime(t *testing.T) {
 func TestEndWorkTime(t *testing.T) {
 	c := NewCalendar()
 	got := c.EndWorkTime(time.Date(2020, 04, 15, 01, 20, 0, 0, time.UTC))
-	expected := time.Date(2020, 04, 15, 18, 0, 0, 0, time.UTC)
+	expected := time.Date(2020, 04, 15, dayEnd, 0, 0, 0, time.UTC)
 	if got != expected {
 		t.Errorf("Calendar.EndWorkTime() = %v, want %v", got, expected)
 	}
@@ -819,22 +819,22 @@ func TestEndWorkTime(t *testing.T) {
 func TestNextWorkStart(t *testing.T) {
 	c := NewCalendar()
 	got := c.NextWorkStart(time.Date(2020, 04, 15, 01, 20, 0, 0, time.UTC))
-	expected := time.Date(2020, 04, 15, 9, 0, 0, 0, time.UTC)
+	expected := time.Date(2020, 04, 15, dayStart, 0, 0, 0, time.UTC)
 	if got != expected {
 		t.Errorf("Calendar.NextWorkStart() = %v, want %v", got, expected)
 	}
 	got = c.NextWorkStart(time.Date(2020, 04, 15, 10, 20, 0, 0, time.UTC))
-	expected = time.Date(2020, 04, 16, 9, 0, 0, 0, time.UTC)
+	expected = time.Date(2020, 04, 16, dayStart, 0, 0, 0, time.UTC)
 	if got != expected {
 		t.Errorf("Calendar.NextWorkStart() = %v, want %v", got, expected)
 	}
 	got = c.NextWorkStart(time.Date(2020, 04, 15, 21, 20, 0, 0, time.UTC))
-	expected = time.Date(2020, 04, 16, 9, 0, 0, 0, time.UTC)
+	expected = time.Date(2020, 04, 16, dayStart, 0, 0, 0, time.UTC)
 	if got != expected {
 		t.Errorf("Calendar.NextWorkStart() = %v, want %v", got, expected)
 	}
 	got = c.NextWorkStart(time.Date(2020, 04, 18, 21, 20, 0, 0, time.UTC))
-	expected = time.Date(2020, 04, 20, 9, 0, 0, 0, time.UTC)
+	expected = time.Date(2020, 04, 20, dayStart, 0, 0, 0, time.UTC)
 	if got != expected {
 		t.Errorf("Calendar.NextWorkStart() = %v, want %v", got, expected)
 	}
@@ -844,13 +844,13 @@ func TestWorkedHours(t *testing.T) {
 	c := NewCalendar()
 
 	got := c.CountWorkHours(time.Now(), time.Now().Add(7*24*time.Hour))
-	expected := time.Duration(5 * 9 * time.Hour)
+	expected := time.Duration(5 * c.DailyWorkedTime())
 	if got != expected {
 		t.Errorf("Calendar.CountWorkHours() = %v, want %v", got, expected)
 	}
 
 	got = c.CountWorkHours(time.Date(2020, 01, 01, 0, 0, 0, 0, time.UTC), time.Date(2019, 01, 01, 0, 0, 0, 0, time.UTC))
-	expected = time.Duration(9 * 261 * time.Hour)
+	expected = time.Duration(261 * c.DailyWorkedTime())
 	if got != expected {
 		t.Errorf("Calendar.CountWorkHours() = %v, want %v", got, expected)
 	}
@@ -860,7 +860,7 @@ func TestWorkedHours(t *testing.T) {
 		t.Errorf("failed to load GMT+1 location: %v", err)
 	}
 
-	got = c.CountWorkHours(time.Date(2020, 4, 15, 10, 0, 0, 0, time.UTC), time.Date(2020, 4, 15, 10, 0, 0, 0, loc))
+	got = c.CountWorkHours(time.Date(2020, 4, 15, dayStart+2, 0, 0, 0, time.UTC), time.Date(2020, 4, 15, dayStart+2, 0, 0, 0, loc))
 	// In april in Spain, there are 2 hours difference with Coordinated Universal Time
 	expected = time.Duration(2 * time.Hour)
 	if got != expected {
@@ -880,21 +880,32 @@ func TestWorkedHours(t *testing.T) {
 func TestAddWorkedHours(t *testing.T) {
 	c := NewCalendar()
 
-	got := c.AddWorkHours(time.Date(2020, 04, 15, 3, 0, 0, 0, time.UTC), 10*time.Hour)
-	expected := time.Date(2020, 04, 16, 10, 0, 0, 0, time.UTC)
+	got := c.AddWorkHours(time.Date(2020, 04, 15, 0, 0, 0, 0, time.UTC), 5*c.DailyWorkedTime())
+	expected := time.Date(2020, 04, 21, dayEnd, 0, 0, 0, time.UTC)
 	if got != expected {
 		t.Errorf("Calendar.AddWorkHours() = %v, want %v", got, expected)
 	}
 
-	got = c.AddWorkHours(time.Date(2020, 04, 15, 3, 0, 0, 0, time.UTC), 5*9*time.Hour)
-	expected = time.Date(2020, 04, 21, 18, 0, 0, 0, time.UTC)
+	got = c.AddWorkHours(time.Date(2020, 04, dayEnd+1, 3, 0, 0, 0, time.UTC), c.DailyWorkedTime())
+	expected = time.Date(2020, 04, 20, dayEnd, 0, 0, 0, time.UTC)
 	if got != expected {
 		t.Errorf("Calendar.AddWorkHours() = %v, want %v", got, expected)
 	}
 
-	got = c.AddWorkHours(time.Date(2020, 04, 19, 3, 0, 0, 0, time.UTC), 9*time.Hour)
-	expected = time.Date(2020, 04, 20, 18, 0, 0, 0, time.UTC)
+	c.SetWorkingHours(9*time.Hour, 18*time.Hour)
+
+	got = c.AddWorkHours(time.Date(2020, 04, 15, 3, 0, 0, 0, time.UTC), 10*time.Hour)
+	expected = time.Date(2020, 04, 16, 10, 0, 0, 0, time.UTC)
 	if got != expected {
 		t.Errorf("Calendar.AddWorkHours() = %v, want %v", got, expected)
 	}
+}
+
+func TestDailyWorkedTime(t *testing.T) {
+	got := NewCalendar().DailyWorkedTime()
+	expected := 8 * time.Hour
+	if got != expected {
+		t.Errorf("Calendar.DailyWorkedTime() = %v, want %v", got, expected)
+	}
+
 }

--- a/holiday_defs_sk_test.go
+++ b/holiday_defs_sk_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-func TestCzechHolidays(t *testing.T) {
+func TestSlovakHolidays(t *testing.T) {
 	c := NewCalendar()
 	c.Observed = ObservedExact
 	AddSlovakHolidays(c)


### PR DESCRIPTION
Addding functions to count number of worked hours between two times,
as well as adding some work time to a given time.

Work time considers all days of the week are worked the same hours and
all holidays are full-day holidays.

timezones and daylight savings are left to the responsibility of the go
time implementation. Hence any trouble in this area should be reported
to go

resolves #26