### PR TITLE
Speed up IsHoliday

### DIFF
--- a/v2/cal.go
+++ b/v2/cal.go
@@ -51,10 +51,11 @@ func (c *Calendar) IsHoliday(date time.Time) (actual, observed bool, h *Holiday)
 		return false, false, nil
 	}
 
+	year, month, day := date.Date()
 	for _, hol := range c.Holidays {
-		act, obs := hol.Calc(date.Year())
-		actMatch := !act.IsZero() && act.Month() == date.Month() && act.Day() == date.Day()
-		obsMatch := !obs.IsZero() && obs.Month() == date.Month() && obs.Day() == date.Day()
+		act, obs := hol.Calc(year)
+		actMatch := !act.IsZero() && act.Month() == month && act.Day() == day
+		obsMatch := !obs.IsZero() && obs.Month() == month && obs.Day() == day
 		if actMatch || obsMatch {
 			return actMatch, obsMatch, hol
 		}


### PR DESCRIPTION
I am running millions of calculations with AddWorkHours(). When I profiled the code I find a very high proportion of the cumulative time is spent in IsWorkday(). With most of that actually inside IsHoliday().

There appears to be the oppurtunity for a simple speedup using Date() instead of the Year(), Month() and Day(). I profiled just that specific change and it was nearly three times faster:

```
var year, day int
var month time.Month

func BenchmarkIsHolidayFast(b *testing.B) {
	zone1 := time.FixedZone("test1", -5)
	t := time.Date(2015, 8, 4, 12, 30, 0, 0, zone1)
	var y, d int
	var m time.Month
	for n := 0; n < b.N; n++ {
		y, m, d = t.Date()
	}
	year, month, day = y, m, d
}

func BenchmarkIsHolidaySlow(b *testing.B) {
	zone1 := time.FixedZone("test1", -5)
	t := time.Date(2015, 8, 4, 12, 30, 0, 0, zone1)
	var y, d int
	var m time.Month
	for n := 0; n < b.N; n++ {
		y = t.Year()
		m = t.Month()
		d = t.Day()
	}
	year, month, day = y, m, d
}
```
The results:
```
$ go test -run=^IsHoliday$ -bench=.
goos: linux
goarch: amd64
pkg: github.com/rickar/cal/v2
BenchmarkIsHolidayFast-2        80226172                14.9 ns/op
BenchmarkIsHolidaySlow-2        25865685                41.4 ns/op
```

I then made the change to IsHoliday() and profiled with a calendar that had four holidays added. The results was about a 30% speedup:

```
goos: linux
goarch: amd64
pkg: github.com/rickar/cal/v2
BenchmarkIsHolidaySlow-2         2312700               492 ns/op
BenchmarkIsHolidayFast-2         3429525               348 ns/op
```

IsHoliday() is used across a large amount of cal's code, so I hope you will consider this PR for merging.