### PR TITLE
Add Irish public holidays

### DIFF
--- a/v2/ie/ie_holidays.go
+++ b/v2/ie/ie_holidays.go
@@ -1,0 +1,84 @@
+// (c) Rick Arnold. Licensed under the BSD license (see LICENSE).
+
+// Package ie provides holiday definitions for the Republic Of Ireland.
+package ie
+
+import (
+	"time"
+
+	"github.com/rickar/cal/v2"
+	"github.com/rickar/cal/v2/aa"
+)
+
+var (
+	// NewYear represents New Year's Day on 1-Jan
+	NewYear = aa.NewYear.Clone(&cal.Holiday{})
+
+	// Patrick's Day Day on 17-Mar
+	SaintPatrickDay = &cal.Holiday{
+		Name:  "Saint Patrick's Day",
+		Month: time.March,
+		Day:   17,
+		Func:  cal.CalcDayOfMonth,
+	}
+
+	// EasterMonday represents Easter Monday - the day after Easter
+	EasterMonday = aa.EasterMonday.Clone(&cal.Holiday{})
+
+	// First Monday in May
+	FirstMondayMay = &cal.Holiday{
+		Name:    "First Monday in May",
+		Month:   time.May,
+		Weekday: time.Monday,
+		Offset:  1,
+		Func:    cal.CalcWeekdayOffset,
+	}
+
+	// First Monday in June
+	FirstMondayJune = &cal.Holiday{
+		Name:    "First Monday in June",
+		Month:   time.June,
+		Weekday: time.Monday,
+		Offset:  1,
+		Func:    cal.CalcWeekdayOffset,
+	}
+
+	// First Monday in August
+	FirstMondayAugust = &cal.Holiday{
+		Name:    "First Monday in August",
+		Month:   time.August,
+		Weekday: time.Monday,
+		Offset:  1,
+		Func:    cal.CalcWeekdayOffset,
+	}
+
+	// Last Monday in October
+	LastMondayInOctober = &cal.Holiday{
+		Name:    "Last Monday in October",
+		Type:    cal.ObservancePublic,
+		Month:   time.October,
+		Weekday: time.Monday,
+		Offset:  -1,
+		Func:    cal.CalcWeekdayOffset,
+	}
+
+	// ChristmasDay represents Christmas Day on 25-Dec
+	ChristmasDay = aa.ChristmasDay.Clone(&cal.Holiday{})
+
+	// Saint Stephen's Day Day on 26-Dec
+	SaintStephenDay = aa.ChristmasDay2.Clone(&cal.Holiday{Name: "Saint Stephen's Day"})
+
+
+	// Holidays provides a list of the standard national holidays
+	Holidays = []*cal.Holiday{
+		NewYear,
+		SaintPatrickDay,
+		EasterMonday,
+		FirstMondayMay,
+		FirstMondayJune,
+		FirstMondayAugust,
+		LastMondayInOctober,
+		ChristmasDay,
+		SaintStephenDay,
+	}
+)

--- a/v2/ie/ie_holidays_test.go
+++ b/v2/ie/ie_holidays_test.go
@@ -1,0 +1,69 @@
+// (c) Rick Arnold. Licensed under the BSD license (see LICENSE).
+
+package ie
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rickar/cal/v2"
+)
+
+func d(y, m, d int) time.Time {
+	return time.Date(y, time.Month(m), d, 0, 0, 0, 0, cal.DefaultLoc)
+}
+
+func TestHolidays(t *testing.T) {
+	tests := []struct {
+		h    *cal.Holiday
+		y    int
+		date time.Time
+	}{
+		{NewYear, 2020, d(2020, 1, 1)},
+		{NewYear, 2021, d(2021, 1, 1)},
+		{NewYear, 2022, d(2022, 1, 1)},
+
+		{SaintPatrickDay, 2020, d(2020, 3, 17)},
+		{SaintPatrickDay, 2021, d(2021, 3, 17)},
+		{SaintPatrickDay, 2022, d(2022, 3, 17)},
+
+		{EasterMonday, 2020, d(2020, 4, 13)},
+		{EasterMonday, 2021, d(2021, 4, 5)},
+		{EasterMonday, 2022, d(2022, 4, 18)},
+
+		{FirstMondayMay, 2020, d(2020, 5, 4)},
+		{FirstMondayMay, 2021, d(2021, 5, 3)},
+		{FirstMondayMay, 2022, d(2022, 5, 2)},
+		{FirstMondayMay, 2023, d(2023, 5, 1)},
+
+		{FirstMondayJune, 2020, d(2020, 6, 1)},
+		{FirstMondayJune, 2021, d(2021, 6, 7)},
+		{FirstMondayJune, 2022, d(2022, 6, 6)},
+		{FirstMondayJune, 2023, d(2023, 6, 5)},
+
+		{FirstMondayAugust, 2020, d(2020, 8, 3)},
+		{FirstMondayAugust, 2021, d(2021, 8, 2)},
+		{FirstMondayAugust, 2022, d(2022, 8, 1)},
+		{FirstMondayAugust, 2023, d(2023, 8, 7)},
+
+		{LastMondayInOctober, 2020, d(2020, 10, 26)},
+		{LastMondayInOctober, 2021, d(2021, 10, 25)},
+		{LastMondayInOctober, 2022, d(2022, 10, 31)},
+		{LastMondayInOctober, 2023, d(2023, 10, 30)},
+
+		{ChristmasDay, 2020, d(2020, 12, 25)},
+		{ChristmasDay, 2021, d(2021, 12, 25)},
+		{ChristmasDay, 2022, d(2022, 12, 25)},
+
+		{SaintStephenDay, 2020, d(2020, 12, 26)},
+		{SaintStephenDay, 2021, d(2021, 12, 26)},
+		{SaintStephenDay, 2022, d(2022, 12, 26)},
+	}
+
+	for _, test := range tests {
+		gotAct, _ := test.h.Calc(test.y)
+		if !gotAct.Equal(test.date) {
+			t.Errorf("%s %d: got actual: %s, want: %s", test.h.Name, test.y, gotAct.String(), test.date.String())
+		}
+	}
+}


### PR DESCRIPTION
Information about public holidays might be found [here](https://www.citizensinformation.ie/en/employment/employment_rights_and_conditions/leave_and_holidays/public_holidays_in_ireland.html)

Short summary
- 9 official public holidays
- no shifts for holidays on weekend
- despite english holidays Good Fridays is not official public holiday