### PR TITLE
Adds Holiday.OffsetDays so that you can easily add the day aft…

### DIFF
--- a/v2/holiday.go
+++ b/v2/holiday.go
@@ -46,7 +46,7 @@ type Holiday struct {
 	Day        int          // the day the holiday occurs
 	Weekday    time.Weekday // the weekday the holiday occurs
 	Offset     int          // the weekday or start date offset the holiday occurs
-	OffsetDays int          // days offset from the date the holiday would occur, used for DayAfter Holidays
+	CalcOffset int          // days offset from the date the holiday occurs, applied after the calculation
 	Julian     bool         // the holiday is based on a Julian calendar
 	Observed   []AltDay     // the substitution days for the holiday
 	Func       HolidayFn    // logic used to determine occurrences
@@ -69,7 +69,7 @@ func (h *Holiday) Clone(overrides *Holiday) *Holiday {
 		Day:         h.Day,
 		Weekday:     h.Weekday,
 		Offset:      h.Offset,
-		OffsetDays:  h.OffsetDays,
+		CalcOffset:  h.CalcOffset,
 		Julian:      h.Julian,
 		Observed:    h.Observed,
 		Func:        h.Func,
@@ -119,8 +119,8 @@ func (h *Holiday) Calc(year int) (actual, observed time.Time) {
 		}
 	}
 	actual = h.Func(h, year)
-	if h.OffsetDays != 0 {
-		actual = time.Date(actual.Year(), actual.Month(), actual.Day()+h.OffsetDays, 0, 0, 0, 0, DefaultLoc)
+	if h.CalcOffset != 0 {
+		actual = actual.AddDate(0, 0, h.CalcOffset)
 	}
 
 	if h.Observed == nil {

--- a/v2/holiday.go
+++ b/v2/holiday.go
@@ -143,6 +143,13 @@ func CalcWeekdayOffset(h *Holiday, year int) time.Time {
 	return DayStart(WeekdayN(year, h.Month, h.Weekday, h.Offset))
 }
 
+// CalcDayAfterWeekdayOffset calculates the occurrence of a holiday that is always a
+// day after another WeekdayOffset holiday.
+func CalcDayAfterWeekdayOffset(h *Holiday, year int) time.Time {
+	dayBefore := DayStart(WeekdayN(year, h.Month, h.Weekday, h.Offset))
+	return time.Date(year, dayBefore.Month(), dayBefore.Day()+1, 0, 0, 0, 0, DefaultLoc)
+}
+
 // CalcWeekdayFrom calculates the occurrence of a holiday that falls on a
 // specific day of the week following a starting date.
 func CalcWeekdayFrom(h *Holiday, year int) time.Time {

--- a/v2/us/us_holidays.go
+++ b/v2/us/us_holidays.go
@@ -102,6 +102,16 @@ var (
 		Func:    cal.CalcWeekdayOffset,
 	}
 
+	// DayAfterThanksgivingDay represents the day after Thanksgiving Day on the fourth Friday in November
+	DayAfterThanksgivingDay = &cal.Holiday{
+		Name:    "Day After Thanksgiving Day",
+		Type:    cal.ObservancePublic,
+		Month:   time.November,
+		Weekday: time.Thursday,
+		Offset:  4,
+		Func:    cal.CalcDayAfterWeekdayOffset,
+	}
+
 	// ChristmasDay represents Christmas Day on the 25-Dec
 	ChristmasDay = aa.ChristmasDay.Clone(&cal.Holiday{Name: "Christmas Day", Type: cal.ObservancePublic, Observed: weekendAlt})
 

--- a/v2/us/us_holidays.go
+++ b/v2/us/us_holidays.go
@@ -104,12 +104,13 @@ var (
 
 	// DayAfterThanksgivingDay represents the day after Thanksgiving Day on the fourth Friday in November
 	DayAfterThanksgivingDay = &cal.Holiday{
-		Name:    "Day After Thanksgiving Day",
-		Type:    cal.ObservancePublic,
-		Month:   time.November,
-		Weekday: time.Thursday,
-		Offset:  4,
-		Func:    cal.CalcDayAfterWeekdayOffset,
+		Name:       "Day After Thanksgiving Day",
+		Type:       cal.ObservancePublic,
+		Month:      time.November,
+		Weekday:    time.Thursday,
+		Offset:     4,
+		OffsetDays: 1,
+		Func:       cal.CalcWeekdayOffset,
 	}
 
 	// ChristmasDay represents Christmas Day on the 25-Dec

--- a/v2/us/us_holidays.go
+++ b/v2/us/us_holidays.go
@@ -109,7 +109,7 @@ var (
 		Month:      time.November,
 		Weekday:    time.Thursday,
 		Offset:     4,
-		OffsetDays: 1,
+		CalcOffset: 1,
 		Func:       cal.CalcWeekdayOffset,
 	}
 

--- a/v2/us/us_holidays_test.go
+++ b/v2/us/us_holidays_test.go
@@ -101,6 +101,11 @@ func TestHolidays(t *testing.T) {
 		{ThanksgivingDay, 2021, d(2021, 11, 25), d(2021, 11, 25)},
 		{ThanksgivingDay, 2022, d(2022, 11, 24), d(2022, 11, 24)},
 
+		{DayAfterThanksgivingDay, 2021, d(2021, 11, 26), d(2021, 11, 26)},
+		{DayAfterThanksgivingDay, 2022, d(2022, 11, 25), d(2022, 11, 25)},
+		{DayAfterThanksgivingDay, 2023, d(2023, 11, 24), d(2023, 11, 24)},
+		{DayAfterThanksgivingDay, 2024, d(2024, 11, 29), d(2024, 11, 29)},
+
 		{ChristmasDay, 2015, d(2015, 12, 25), d(2015, 12, 25)},
 		{ChristmasDay, 2016, d(2016, 12, 25), d(2016, 12, 26)},
 		{ChristmasDay, 2017, d(2017, 12, 25), d(2017, 12, 25)},


### PR DESCRIPTION
Adds Holiday.OffsetDays so that you can easily add the day after another weekday offset holiday.  This is needed in case the day after happens to be a different offset than the holiday day.  For instance, US Thanksgiving in 2024 is on the 4th Thursday, but the day after is the 5th Friday.

Closes #57
