### PR TITLE
add Saint Brigid's day in Ireland

### DIFF
--- a/v2/ie/ie_holidays.go
+++ b/v2/ie/ie_holidays.go
@@ -14,6 +14,26 @@ var (
 	// NewYear represents New Year's Day on 1-Jan
 	NewYear = aa.NewYear.Clone(&cal.Holiday{})
 
+	// SaintBrigidDay represents Saint Patrick's Day on 17-Mar
+	SaintBrigidDay = &cal.Holiday{
+		Name:      "Saint Brigid’s Day",
+		Month:     time.February,
+		Weekday:   time.Monday,
+		Offset:    1,
+		Func:      CalcIfFirstFallsOnFriday,
+		StartYear: 2023,
+	}
+
+	// ExtraPublicHoliday2022 represents extra public holiday in 2022
+	ExtraPublicHoliday2022 = &cal.Holiday{
+		Name:      "Extra Public Holiday 2022",
+		Month:     time.March,
+		Day:       18,
+		StartYear: 2022,
+		EndYear:   2022,
+		Func:      cal.CalcDayOfMonth,
+	}
+
 	// SaintPatrickDay represents Saint Patrick's Day on 17-Mar
 	SaintPatrickDay = &cal.Holiday{
 		Name:  "Saint Patrick's Day",
@@ -71,6 +91,8 @@ var (
 	// Holidays provides a list of the standard national holidays
 	Holidays = []*cal.Holiday{
 		NewYear,
+		ExtraPublicHoliday2022,
+		SaintBrigidDay,
 		SaintPatrickDay,
 		EasterMonday,
 		FirstMondayMay,
@@ -81,3 +103,13 @@ var (
 		SaintStephenDay,
 	}
 )
+
+func CalcIfFirstFallsOnFriday(h *cal.Holiday, year int) time.Time {
+	fistFriday := cal.DayStart(cal.WeekdayN(year, h.Month, time.Friday, 1))
+	// if 1st falls on a Friday
+	if fistFriday.Day() == 1 {
+		return fistFriday
+	}
+
+	return cal.DayStart(cal.WeekdayN(year, h.Month, h.Weekday, h.Offset))
+}

--- a/v2/ie/ie_holidays_test.go
+++ b/v2/ie/ie_holidays_test.go
@@ -23,6 +23,12 @@ func TestHolidays(t *testing.T) {
 		{NewYear, 2021, d(2021, 1, 1)},
 		{NewYear, 2022, d(2022, 1, 1)},
 
+		{ExtraPublicHoliday2022, 2022, d(2022, 3, 18)},
+
+		{SaintBrigidDay, 2023, d(2023, 2, 6)},
+		{SaintBrigidDay, 2024, d(2024, 2, 5)},
+		{SaintBrigidDay, 2030, d(2030, 2, 1)},
+
 		{SaintPatrickDay, 2020, d(2020, 3, 17)},
 		{SaintPatrickDay, 2021, d(2021, 3, 17)},
 		{SaintPatrickDay, 2022, d(2022, 3, 17)},


### PR DESCRIPTION
In 2022, an extra once-off public holiday will take place on Friday, 18 March.

From 2023, there will be a new annual public holiday in early February to mark St Brigid’s Day. The public holiday will be the first Monday in February, except where St Brigid’s day (1 February) happens to fall on a Friday, in which case that Friday 1 February will be a public holiday.

https://www.citizensinformation.ie/en/employment/employment_rights_and_conditions/leave_and_holidays/public_holidays_in_ireland.html