### PR TITLE
Add NextWorkdayEnd

### DIFF
--- a/v2/cal_business.go
+++ b/v2/cal_business.go
@@ -320,6 +320,19 @@ func (c *BusinessCalendar) NextWorkdayStart(date time.Time) time.Time {
 	return c.WorkdayStart(t)
 }
 
+// NextWorkdayEnd reports the end of the current or next work day from the given date.
+func (c *BusinessCalendar) NextWorkdayEnd(date time.Time) time.Time {
+	t := date
+	if date.After(c.WorkdayEnd(date)) {
+		t = t.Add(24 * time.Hour)
+	}
+
+	for !c.IsWorkday(t) {
+		t = t.Add(24 * time.Hour)
+	}
+	return c.WorkdayEnd(t)
+}
+
 // WorkHoursInRange reports the working hours between the given start and end
 // dates.
 func (c *BusinessCalendar) WorkHoursInRange(start, end time.Time) time.Duration {

--- a/v2/cal_business_test.go
+++ b/v2/cal_business_test.go
@@ -479,6 +479,39 @@ func TestNextWorkdayStart(t *testing.T) {
 	}
 }
 
+func TestNextWorkdayEnd(t *testing.T) {
+	cal1 := NewBusinessCalendar()
+	cal2 := NewBusinessCalendar()
+	cal2.WorkdayStartFunc = func(date time.Time) time.Time {
+		return time.Date(date.Year(), date.Month(), date.Day(), date.Day()%12, 30, 0, 0, time.UTC)
+	}
+	cal2.WorkdayEndFunc = func(date time.Time) time.Time {
+		return time.Date(date.Year(), date.Month(), date.Day(), date.Day()%12+6, 45, 0, 0, time.UTC)
+	}
+
+	tests := []struct {
+		c    *BusinessCalendar
+		d    time.Time
+		want time.Time
+	}{
+		{cal1, dt(2020, 4, 1, 6, 0), dt(2020, 4, 1, 17, 0)},
+		{cal1, dt(2020, 4, 1, 20, 0), dt(2020, 4, 2, 17, 0)},
+		{cal1, dt(2020, 4, 4, 12, 0), dt(2020, 4, 6, 17, 0)},
+		{cal1, dt(2020, 4, 5, 12, 0), dt(2020, 4, 6, 17, 0)},
+
+		{cal2, dt(2020, 4, 1, 3, 0), dt(2020, 4, 1, 7, 45)},
+		{cal2, dt(2020, 4, 6, 8, 0), dt(2020, 4, 6, 12, 45)},
+		{cal2, dt(2020, 4, 6, 22, 0), dt(2020, 4, 7, 13, 45)},
+	}
+
+	for i, test := range tests {
+		got := test.c.NextWorkdayEnd(test.d)
+		if got != test.want {
+			t.Errorf("got: %s; want: %s (%d)", got, test.want, i)
+		}
+	}
+}
+
 func TestWorkHoursInRange(t *testing.T) {
 	cal1 := NewBusinessCalendar()
 	cal2 := NewBusinessCalendar()


### PR DESCRIPTION
Hello

I recently used `cal` calendars and I needed to find cut-off times, aka the end of the current working day or the next one.

I implement `NextWorkdayEnd`

Happy to share. Let me know if anything is missing from the PR.