### PR TITLE
Add Juneteenth to us.Holidays list

### DIFF
--- a/v2/us/us_holidays.go
+++ b/v2/us/us_holidays.go
@@ -133,6 +133,7 @@ var (
 		MlkDay,
 		PresidentsDay,
 		MemorialDay,
+		Juneteenth,
 		IndependenceDay,
 		LaborDay,
 		ColumbusDay,


### PR DESCRIPTION
Add `Juneteenth` to the `us.Holidays` list of standard national holidays as per https://www.federalreserve.gov/aboutthefed/k8.htm