### PR TITLE
au: Add National Day of Mourning for Her Majesty the Queen

### DIFF
--- a/v2/au/au_holidays.go
+++ b/v2/au/au_holidays.go
@@ -238,6 +238,17 @@ var (
 			{Day: time.Sunday, Offset: 2},
 			{Day: time.Monday, Offset: 1}}})
 
+	// MourningDay2022 represents the National Day of Mourning for Her Majesty the Queen.
+	MourningDay2022 = &cal.Holiday{
+		Name:      "National Day of Mourning for Her Majesty the Queen",
+		Type:      cal.ObservancePublic,
+		Month:     time.September,
+		Day:       22,
+		StartYear: 2022,
+		EndYear:   2022,
+		Func:      cal.CalcDayOfMonth,
+	}
+
 	// HolidaysACT provides a list of standard holidays in the Australian Capital Territory region.
 	HolidaysACT = []*cal.Holiday{
 		NewYear,
@@ -250,6 +261,7 @@ var (
 		AnzacDayActWa,
 		ReconciliationDay,
 		QueensBirthday,
+		MourningDay2022,
 		LabourDayActNswSa,
 		ChristmasDay,
 		BoxingDay,
@@ -265,6 +277,7 @@ var (
 		EasterMonday,
 		AnzacDay,
 		QueensBirthday,
+		MourningDay2022,
 		LabourDayActNswSa,
 		ChristmasDay,
 		BoxingDay,
@@ -281,6 +294,7 @@ var (
 		LabourDayNtQld,
 		QueensBirthday,
 		PicnicDay,
+		MourningDay2022,
 		ChristmasDay,
 		BoxingDay,
 	}
@@ -295,6 +309,7 @@ var (
 		EasterMonday,
 		AnzacDayNtQldSa,
 		LabourDayNtQld,
+		MourningDay2022,
 		QueensBirthdayQld,
 		ChristmasDay,
 		BoxingDay,
@@ -310,6 +325,7 @@ var (
 		EasterMonday,
 		AnzacDayNtQldSa,
 		QueensBirthday,
+		MourningDay2022,
 		LabourDayActNswSa,
 		ChristmasDay,
 		ProclamationDay,
@@ -324,6 +340,7 @@ var (
 		EasterMonday,
 		AnzacDay,
 		QueensBirthday,
+		MourningDay2022,
 		ChristmasDay,
 		BoxingDay,
 	}
@@ -339,6 +356,7 @@ var (
 		EasterMonday,
 		AnzacDay,
 		QueensBirthday,
+		MourningDay2022,
 		FridayBeforeAflFinal,
 		MelbourneCup,
 		ChristmasDay,
@@ -355,6 +373,7 @@ var (
 		AnzacDayActWa,
 		WesternAustraliaDay,
 		QueensBirthdayWa,
+		MourningDay2022,
 		ChristmasDay,
 		BoxingDay,
 	}

--- a/v2/au/au_holidays_test.go
+++ b/v2/au/au_holidays_test.go
@@ -262,6 +262,8 @@ func TestHolidays(t *testing.T) {
 		{ProclamationDay, 2020, d(2020, 12, 26), d(2020, 12, 28)},
 		{ProclamationDay, 2021, d(2021, 12, 26), d(2021, 12, 28)},
 		{ProclamationDay, 2022, d(2022, 12, 26), d(2022, 12, 27)},
+
+		{MourningDay2022, 2022, d(2022, 9, 22), d(2022, 9, 22)},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This is a one-off public holiday for 2022 that will be observed by all of the states and territories.

> The Prime Minister has [declared](https://www.pm.gov.au/media/commemorating-her-majesty-queen-elizabeth-ii) that Thursday 22 September 2022 will be a public holiday for a National Day of Mourning for Her Majesty the Queen.

Source: https://www.fairwork.gov.au/newsroom/news/national-day-mourning-and-other-upcoming-public-holidays