### PR TITLE
au: Fix FridayBeforeAflFinal holiday

### DIFF
--- a/v2/au/au_holidays.go
+++ b/v2/au/au_holidays.go
@@ -180,13 +180,10 @@ var (
 	}
 
 	// FridayBeforeAflFinal represents the Friday before the AFL Grand Final;
-	// normally on the last Friday of September but subject to AFL schedules
+	// normally on the Friday before the last Saturday of September but subject to AFL schedules
 	FridayBeforeAflFinal = &cal.Holiday{
 		Name:      "Friday before the AFL Grand Final",
 		Type:      cal.ObservancePublic,
-		Month:     time.September,
-		Weekday:   time.Friday,
-		Offset:    -1,
 		Func:      calcFridayBeforeAflFinal,
 		StartYear: 2015,
 	}
@@ -379,13 +376,16 @@ var (
 	}
 )
 
-func calcFridayBeforeAflFinal(h *cal.Holiday, year int) time.Time {
+func calcFridayBeforeAflFinal(_ *cal.Holiday, year int) time.Time {
 	switch year {
 	case 2015:
 		return time.Date(year, time.October, 2, 0, 0, 0, 0, cal.DefaultLoc)
+	case 2016:
+		return time.Date(year, time.September, 30, 0, 0, 0, 0, cal.DefaultLoc)
 	case 2020:
 		return time.Date(year, time.October, 23, 0, 0, 0, 0, cal.DefaultLoc)
 	default:
-		return cal.CalcWeekdayOffset(h, year)
+		aflFinalDay := cal.DayStart(cal.WeekdayN(year, time.September, time.Saturday, -1))
+		return aflFinalDay.AddDate(0, 0, -1)
 	}
 }

--- a/v2/au/au_holidays_test.go
+++ b/v2/au/au_holidays_test.go
@@ -207,7 +207,7 @@ func TestHolidays(t *testing.T) {
 		{FridayBeforeAflFinal, 2019, d(2019, 9, 27), d(2019, 9, 27)},
 		{FridayBeforeAflFinal, 2020, d(2020, 10, 23), d(2020, 10, 23)},
 		{FridayBeforeAflFinal, 2021, d(2021, 9, 24), d(2021, 9, 24)},
-		{FridayBeforeAflFinal, 2022, d(2022, 9, 30), d(2022, 9, 30)},
+		{FridayBeforeAflFinal, 2022, d(2022, 9, 23), d(2022, 9, 23)},
 
 		{QueensBirthdayQld, 2015, d(2015, 10, 5), d(2015, 10, 5)},
 		{QueensBirthdayQld, 2016, d(2016, 10, 3), d(2016, 10, 3)},


### PR DESCRIPTION
The AFL Final day is normally on the last Saturday of September, and the holiday is the Friday before that, which is not always the last Friday of the month.