### PR TITLE
Danish "Store bededag" has been abolished from 2024

### DIFF
--- a/v2/dk/dk_holidays.go
+++ b/v2/dk/dk_holidays.go
@@ -25,10 +25,12 @@ var (
 
 	// StoreBededag represents General Prayer Day on the fourth Friday after Easter
 	StoreBededag = &cal.Holiday{
-		Name:   "Store bededag",
-		Type:   cal.ObservancePublic,
-		Offset: 26,
-		Func:   cal.CalcEasterOffset,
+		Name:      "Store bededag",
+		Type:      cal.ObservancePublic,
+		Offset:    26,
+		Func:      cal.CalcEasterOffset,
+		StartYear: 1686,
+		EndYear:   2023,
 	}
 
 	// KristiHimmelfartsdag represents Ascension Day on the 39th day after Easter

--- a/v2/dk/dk_holidays_test.go
+++ b/v2/dk/dk_holidays_test.go
@@ -56,6 +56,8 @@ func TestHolidays(t *testing.T) {
 		{AndenPaaskedag, 2021, d(2021, 4, 5), d(2021, 4, 5)},
 		{AndenPaaskedag, 2022, d(2022, 4, 18), d(2022, 4, 18)},
 
+		{StoreBededag, 1685, time.Time{}, time.Time{}},
+		{StoreBededag, 1686, d(1686, 5, 10), d(1686, 5, 10)},
 		{StoreBededag, 2015, d(2015, 5, 1), d(2015, 5, 1)},
 		{StoreBededag, 2016, d(2016, 4, 22), d(2016, 4, 22)},
 		{StoreBededag, 2017, d(2017, 5, 12), d(2017, 5, 12)},
@@ -64,6 +66,9 @@ func TestHolidays(t *testing.T) {
 		{StoreBededag, 2020, d(2020, 5, 8), d(2020, 5, 8)},
 		{StoreBededag, 2021, d(2021, 4, 30), d(2021, 4, 30)},
 		{StoreBededag, 2022, d(2022, 5, 13), d(2022, 5, 13)},
+		{StoreBededag, 2023, d(2023, 5, 5), d(2023, 5, 5)},
+		{StoreBededag, 2024, time.Time{}, time.Time{}},
+		{StoreBededag, 2025, time.Time{}, time.Time{}},
 
 		{KristiHimmelfartsdag, 2015, d(2015, 5, 14), d(2015, 5, 14)},
 		{KristiHimmelfartsdag, 2016, d(2016, 5, 5), d(2016, 5, 5)},


### PR DESCRIPTION
The Danish Parliament has abolished "Store bededag" from 2024.

See https://www.ft.dk/samling/20222/lovforslag/L13/index.htm
