### PR TITLE
feat: add support for setting '24h' as end work hour

### DIFF
--- a/v2/cal_business.go
+++ b/v2/cal_business.go
@@ -109,9 +109,17 @@ func (c *BusinessCalendar) IsWorkTime(date time.Time) bool {
 		startSecond = startTime.Second()
 	}
 	if c.WorkdayEndFunc == nil {
-		endHour = int(c.workdayEnd.Hours()) % 24
-		endMinute = int(c.workdayEnd.Minutes()) % 60
-		endSecond = int(c.workdayEnd.Seconds()) % 60
+		// Using 24h as "till the end of day" seems to be pretty common.
+		// By subtracting a second we get the desired behavior.
+		if c.workdayEnd == 24*time.Hour {
+			endHour = 23
+			endMinute = 59
+			endSecond = 59
+		} else {
+			endHour = int(c.workdayEnd.Hours()) % 24
+			endMinute = int(c.workdayEnd.Minutes()) % 60
+			endSecond = int(c.workdayEnd.Seconds()) % 60
+		}
 	} else {
 		endTime := c.WorkdayEndFunc(date)
 		endHour = endTime.Hour()

--- a/v2/cal_business_test.go
+++ b/v2/cal_business_test.go
@@ -40,11 +40,16 @@ func TestSetWorkday(t *testing.T) {
 	}
 }
 
-func TestSetWorkingHours(t *testing.T) {
+func TestSetWorkHours(t *testing.T) {
 	b := NewBusinessCalendar()
 	b.SetWorkHours(8*time.Hour+30*time.Minute, 18*time.Hour+15*time.Minute)
 	if b.workdayStart != 8*time.Hour+30*time.Minute || b.workdayEnd != 18*time.Hour+15*time.Minute {
 		t.Errorf("invalid work hours; want 9am-5pm; got: %d, %d", b.workdayStart, b.workdayEnd)
+	}
+
+	b.SetWorkHours(6*time.Hour, 24*time.Hour)
+	if b.workdayStart != 6*time.Hour || b.workdayEnd != 24*time.Hour {
+		t.Errorf("invalid work hours; want 6am to end of day; got: %d, %d", b.workdayStart, b.workdayEnd)
 	}
 }
 
@@ -100,12 +105,16 @@ func TestIsWorkday(t *testing.T) {
 func TestIsWorkTime(t *testing.T) {
 	cal1 := NewBusinessCalendar()
 	cal2 := NewBusinessCalendar()
+	cal3 := NewBusinessCalendar()
 	cal2.WorkdayStartFunc = func(date time.Time) time.Time {
 		return time.Date(date.Year(), date.Month(), date.Day(), date.Day()%12, 30, 0, 0, time.UTC)
 	}
 	cal2.WorkdayEndFunc = func(date time.Time) time.Time {
 		return time.Date(date.Year(), date.Month(), date.Day(), date.Day()%12+6, 45, 0, 0, time.UTC)
 	}
+	cal3.SetWorkday(time.Thursday, true)
+	cal3.SetWorkday(time.Friday, true)
+	cal3.SetWorkHours(6*time.Hour, 24*time.Hour)
 
 	tests := []struct {
 		c    *BusinessCalendar
@@ -121,6 +130,9 @@ func TestIsWorkTime(t *testing.T) {
 		{cal2, dt(2020, 4, 1, 0, 00), false},
 		{cal2, dt(2020, 4, 1, 7, 00), true},
 		{cal2, dt(2020, 4, 1, 7, 50), false},
+
+		{cal3, dt(2023, 10, 19, 23, 59), true},
+		{cal3, dt(2023, 10, 20, 0, 0), false},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
I think it should be possible to configure "till end of day" using `24h` using `SetWorkHours()` in combination with `IsWorkTime()`. 

Until now using `24h` failed (silently) because by applying module it drops to `0` and therefore `IsWorkTIme` always returns false. Code using it that way basically is broken.

Therefore, this also should not affect backwards compatibility.

WDYT?