### PR TITLE
Fix work time check issue when startHour and endHour are the same

### DIFF
--- a/v2/cal_business.go
+++ b/v2/cal_business.go
@@ -120,11 +120,16 @@ func (c *BusinessCalendar) IsWorkTime(date time.Time) bool {
 	}
 
 	h, m, s := date.Clock()
-	return (h == startHour && m == startMinute && s >= startSecond) ||
-		(h == startHour && m > startMinute) ||
-		(h > startHour && h < endHour) ||
-		(h == endHour && m < endMinute) ||
-		(h == endHour && m == endMinute && s <= endSecond)
+
+	timeOfDateCalculator := func(hour, minute, second int) time.Duration {
+		return time.Duration(hour)*time.Hour + time.Duration(minute)*time.Minute + time.Duration(second)*time.Second
+	}
+
+	timeOfDate := timeOfDateCalculator(h, m, s)
+	startTimeOfDate := timeOfDateCalculator(startHour, startMinute, startSecond)
+	endTimeOfDate := timeOfDateCalculator(endHour, endMinute, endSecond)
+
+	return timeOfDate >= startTimeOfDate && timeOfDate <= endTimeOfDate
 }
 
 // WorkdaysRemain reports the total number of remaining workdays in the month

--- a/v2/cal_business_test.go
+++ b/v2/cal_business_test.go
@@ -100,11 +100,19 @@ func TestIsWorkday(t *testing.T) {
 func TestIsWorkTime(t *testing.T) {
 	cal1 := NewBusinessCalendar()
 	cal2 := NewBusinessCalendar()
+	cal3 := NewBusinessCalendar()
 	cal2.WorkdayStartFunc = func(date time.Time) time.Time {
 		return time.Date(date.Year(), date.Month(), date.Day(), date.Day()%12, 30, 0, 0, time.UTC)
 	}
 	cal2.WorkdayEndFunc = func(date time.Time) time.Time {
 		return time.Date(date.Year(), date.Month(), date.Day(), date.Day()%12+6, 45, 0, 0, time.UTC)
+	}
+
+	cal3.WorkdayStartFunc = func(date time.Time) time.Time {
+		return time.Date(date.Year(), date.Month(), date.Day(), date.Day()%12, 30, 0, 0, time.UTC)
+	}
+	cal3.WorkdayEndFunc = func(date time.Time) time.Time {
+		return time.Date(date.Year(), date.Month(), date.Day(), date.Day()%12, 45, 0, 0, time.UTC)
 	}
 
 	tests := []struct {
@@ -121,6 +129,12 @@ func TestIsWorkTime(t *testing.T) {
 		{cal2, dt(2020, 4, 1, 0, 00), false},
 		{cal2, dt(2020, 4, 1, 7, 00), true},
 		{cal2, dt(2020, 4, 1, 7, 50), false},
+
+		{cal3, dt(2020, 4, 1, 1, 30), true},
+		{cal3, dt(2020, 4, 1, 0, 00), false},
+		{cal3, dt(2020, 4, 1, 1, 35), true},
+		{cal3, dt(2020, 4, 1, 1, 45), true},
+		{cal3, dt(2020, 4, 1, 1, 46), false},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
# Why

1. When the `startHour` and `endHour` the same, `IsWorkTime` returns incorrectly

# What

1. Use time.Duration to check if the working time (time of date) is in the range or not.