### PR TITLE
au: Fix KingsBirthdayWa holiday

### DIFF
--- a/v2/au/au_holidays.go
+++ b/v2/au/au_holidays.go
@@ -177,6 +177,16 @@ var (
 		Weekday: time.Monday,
 		Offset:  -1,
 		Func:    cal.CalcWeekdayOffset,
+		EndYear: 2021,
+	}
+
+	// KingsBirthdayWa represents King's Birthday in WA previously known as the Queen’s Birthday;
+	// there is no firm rule to determine this date, though it is usually the last Monday of September
+	KingsBirthdayWa = &cal.Holiday{
+		Name:      "King's Birthday",
+		Type:      cal.ObservancePublic,
+		Func:      calcKingsBirthdayWa,
+		StartYear: 2022,
 	}
 
 	// FridayBeforeAflFinal represents the Friday before the AFL Grand Final;
@@ -370,6 +380,7 @@ var (
 		AnzacDayActWa,
 		WesternAustraliaDay,
 		QueensBirthdayWa,
+		KingsBirthdayWa,
 		MourningDay2022,
 		ChristmasDay,
 		BoxingDay,
@@ -387,5 +398,14 @@ func calcFridayBeforeAflFinal(_ *cal.Holiday, year int) time.Time {
 	default:
 		aflFinalDay := cal.DayStart(cal.WeekdayN(year, time.September, time.Saturday, -1))
 		return aflFinalDay.AddDate(0, 0, -1)
+	}
+}
+
+func calcKingsBirthdayWa(_ *cal.Holiday, year int) time.Time {
+	switch year {
+	case 2024:
+		return time.Date(year, time.September, 23, 0, 0, 0, 0, cal.DefaultLoc)
+	default:
+		return cal.DayStart(cal.WeekdayN(year, time.September, time.Monday, -1))
 	}
 }

--- a/v2/au/au_holidays_test.go
+++ b/v2/au/au_holidays_test.go
@@ -198,7 +198,9 @@ func TestHolidays(t *testing.T) {
 		{QueensBirthdayWa, 2019, d(2019, 9, 30), d(2019, 9, 30)},
 		{QueensBirthdayWa, 2020, d(2020, 9, 28), d(2020, 9, 28)},
 		{QueensBirthdayWa, 2021, d(2021, 9, 27), d(2021, 9, 27)},
-		{QueensBirthdayWa, 2022, d(2022, 9, 26), d(2022, 9, 26)},
+
+		{KingsBirthdayWa, 2022, d(2022, 9, 26), d(2022, 9, 26)},
+		{KingsBirthdayWa, 2024, d(2024, 9, 23), d(2024, 9, 23)},
 
 		{FridayBeforeAflFinal, 2015, d(2015, 10, 2), d(2015, 10, 2)},
 		{FridayBeforeAflFinal, 2016, d(2016, 9, 30), d(2016, 9, 30)},


### PR DESCRIPTION
From 2022 Queen’s Birthday public holiday in WA changed to King’s Birthday.

The governor of Western Australia each year proclaims the day on which the state will observe the King’s Birthday.

There is no firm rule to determine this date, though it is usually the last Monday of September.