### PR TITLE
feat: Add holidays for Malta

### DIFF
--- a/v2/mt/mt_holidays.go
+++ b/v2/mt/mt_holidays.go
@@ -1,0 +1,122 @@
+// (c) Rick Arnold. Licensed under the BSD license (see LICENSE).
+
+// Package mt provides holiday definitions for Malta.
+package mt
+
+import (
+	"time"
+
+	"github.com/rickar/cal/v2"
+	"github.com/rickar/cal/v2/aa"
+)
+
+var (
+	// L-ewwelTasSena represents New Year's Day on 1-Jan
+	LEwwelTasSena = aa.NewYear.Clone(&cal.Holiday{Name: "L-ewwel tas-Sena", Type: cal.ObservancePublic})
+
+	// NawfragjuSanPawl represents Feast of St. Paul's Shipwreck on 10-Feb
+	NawfragjuSanPawl = &cal.Holiday{
+		Name:  "Nawfraġju ta' San Pawl",
+		Type:  cal.ObservancePublic,
+		Month: time.February,
+		Day:   10,
+		Func:  cal.CalcDayOfMonth,
+	}
+
+	// SanGuzepp represents Feast of St. Joseph on 19-Mar
+	SanGuzepp = &cal.Holiday{
+		Name:  "San Ġużepp",
+		Type:  cal.ObservancePublic,
+		Month: time.March,
+		Day:   19,
+		Func:  cal.CalcDayOfMonth,
+	}
+
+	// Il-GimghaKbira represents Good Friday (movable)
+	IlGimghaLKbira = aa.GoodFriday.Clone(&cal.Holiday{Name: "Il-Ġimgħa l-Kbira", Type: cal.ObservancePublic})
+
+	// JumIl-Ħelsien represents Freedom Day on 31-Mar
+	JumIlĦelsien = &cal.Holiday{
+		Name:  "Jum il-Ħelsien",
+		Type:  cal.ObservancePublic,
+		Month: time.March,
+		Day:   31,
+		Func:  cal.CalcDayOfMonth,
+	}
+
+	// JumIl-Ħaddiem represents Labour Day on 1-May
+	JumIlĦaddiem = aa.WorkersDay.Clone(&cal.Holiday{Name: "Jum il-Ħaddiem", Type: cal.ObservancePublic})
+
+	// SetteGiugno represents Sette Giugno on 7-Jun
+	SetteGiugno = &cal.Holiday{
+		Name:  "Sette Giugno",
+		Type:  cal.ObservancePublic,
+		Month: time.June,
+		Day:   7,
+		Func:  cal.CalcDayOfMonth,
+	}
+
+	// L-Imnarja represents Feast of St. Peter and St. Paul on 29-Jun
+	LImnarja = &cal.Holiday{
+		Name:  "L-Imnarja",
+		Type:  cal.ObservancePublic,
+		Month: time.June,
+		Day:   29,
+		Func:  cal.CalcDayOfMonth,
+	}
+
+	// SantaMarija represents Feast of the Assumption of Mary on 15-Aug
+	SantaMarija = aa.AssumptionOfMary.Clone(&cal.Holiday{Name: "Santa Marija", Type: cal.ObservancePublic})
+
+	// JumIl-Vitorja represents Victory Day on 8-Sep
+	JumIlVitorja = &cal.Holiday{
+		Name:  "Jum il-Vitorja",
+		Type:  cal.ObservancePublic,
+		Month: time.September,
+		Day:   8,
+		Func:  cal.CalcDayOfMonth,
+	}
+
+	// JumL-Indipendenza represents Independence Day on 21-Sep
+	JumLIndipendenza = &cal.Holiday{
+		Name:  "Jum l-Indipendenza",
+		Type:  cal.ObservancePublic,
+		Month: time.September,
+		Day:   21,
+		Func:  cal.CalcDayOfMonth,
+	}
+
+	// Il-Kuncizzjoni represents Feast of the Immaculate Conception on 8-Dec
+	IlKuncizzjoni = aa.ImmaculateConception.Clone(&cal.Holiday{Name: "Il-Kunċizzjoni", Type: cal.ObservancePublic})
+
+	// JumIr-Repubblika represents Republic Day on 13-Dec
+	JumIrRepubblika = &cal.Holiday{
+		Name:  "Jum ir-Repubblika",
+		Type:  cal.ObservancePublic,
+		Month: time.December,
+		Day:   13,
+		Func:  cal.CalcDayOfMonth,
+	}
+
+	// Il-Milied represents Christmas Day on 25-Dec
+	IlMilied = aa.ChristmasDay.Clone(&cal.Holiday{Name: "Il-Milied", Type: cal.ObservancePublic})
+
+	// Holidays provides a list of the standard national holidays
+	Holidays = []*cal.Holiday{
+		LEwwelTasSena,
+		NawfragjuSanPawl,
+		SanGuzepp,
+		IlGimghaLKbira,
+		JumIlĦelsien,
+		JumIlĦaddiem,
+		SetteGiugno,
+		LImnarja,
+		SantaMarija,
+		JumIlVitorja,
+		JumLIndipendenza,
+		IlKuncizzjoni,
+		JumIrRepubblika,
+		IlMilied,
+	}
+)
+

--- a/v2/mt/mt_holidays.go
+++ b/v2/mt/mt_holidays.go
@@ -119,4 +119,3 @@ var (
 		IlMilied,
 	}
 )
-

--- a/v2/mt/mt_holidays_test.go
+++ b/v2/mt/mt_holidays_test.go
@@ -1,0 +1,89 @@
+// (c) Rick Arnold. Licensed under the BSD license (see LICENSE).
+
+package mt
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rickar/cal/v2"
+)
+
+func d(y, m, d int) time.Time {
+	return time.Date(y, time.Month(m), d, 0, 0, 0, 0, cal.DefaultLoc)
+}
+
+func TestHolidays(t *testing.T) {
+	tests := []struct {
+		h       *cal.Holiday
+		y       int
+		wantAct time.Time
+		wantObs time.Time
+	}{
+		{LEwwelTasSena, 2015, d(2015, 1, 1), d(2015, 1, 1)},
+		{LEwwelTasSena, 2020, d(2020, 1, 1), d(2020, 1, 1)},
+		{LEwwelTasSena, 2022, d(2022, 1, 1), d(2022, 1, 1)},
+
+		{NawfragjuSanPawl, 2015, d(2015, 2, 10), d(2015, 2, 10)},
+		{NawfragjuSanPawl, 2020, d(2020, 2, 10), d(2020, 2, 10)},
+		{NawfragjuSanPawl, 2022, d(2022, 2, 10), d(2022, 2, 10)},
+
+		{SanGuzepp, 2015, d(2015, 3, 19), d(2015, 3, 19)},
+		{SanGuzepp, 2020, d(2020, 3, 19), d(2020, 3, 19)},
+		{SanGuzepp, 2022, d(2022, 3, 19), d(2022, 3, 19)},
+
+		{IlGimghaLKbira, 2015, d(2015, 4, 3), d(2015, 4, 3)},
+		{IlGimghaLKbira, 2020, d(2020, 4, 10), d(2020, 4, 10)},
+		{IlGimghaLKbira, 2022, d(2022, 4, 15), d(2022, 4, 15)},
+
+		{JumIlĦelsien, 2015, d(2015, 3, 31), d(2015, 3, 31)},
+		{JumIlĦelsien, 2020, d(2020, 3, 31), d(2020, 3, 31)},
+		{JumIlĦelsien, 2022, d(2022, 3, 31), d(2022, 3, 31)},
+
+		{JumIlĦaddiem, 2015, d(2015, 5, 1), d(2015, 5, 1)},
+		{JumIlĦaddiem, 2020, d(2020, 5, 1), d(2020, 5, 1)},
+		{JumIlĦaddiem, 2022, d(2022, 5, 1), d(2022, 5, 1)},
+
+		{SetteGiugno, 2015, d(2015, 6, 7), d(2015, 6, 7)},
+		{SetteGiugno, 2020, d(2020, 6, 7), d(2020, 6, 7)},
+		{SetteGiugno, 2022, d(2022, 6, 7), d(2022, 6, 7)},
+
+		{LImnarja, 2015, d(2015, 6, 29), d(2015, 6, 29)},
+		{LImnarja, 2020, d(2020, 6, 29), d(2020, 6, 29)},
+		{LImnarja, 2022, d(2022, 6, 29), d(2022, 6, 29)},
+
+		{SantaMarija, 2015, d(2015, 8, 15), d(2015, 8, 15)},
+		{SantaMarija, 2020, d(2020, 8, 15), d(2020, 8, 15)},
+		{SantaMarija, 2022, d(2022, 8, 15), d(2022, 8, 15)},
+
+		{JumIlVitorja, 2015, d(2015, 9, 8), d(2015, 9, 8)},
+		{JumIlVitorja, 2020, d(2020, 9, 8), d(2020, 9, 8)},
+		{JumIlVitorja, 2022, d(2022, 9, 8), d(2022, 9, 8)},
+
+		{JumLIndipendenza, 2015, d(2015, 9, 21), d(2015, 9, 21)},
+		{JumLIndipendenza, 2020, d(2020, 9, 21), d(2020, 9, 21)},
+		{JumLIndipendenza, 2022, d(2022, 9, 21), d(2022, 9, 21)},
+
+		{IlKuncizzjoni, 2015, d(2015, 12, 8), d(2015, 12, 8)},
+		{IlKuncizzjoni, 2020, d(2020, 12, 8), d(2020, 12, 8)},
+		{IlKuncizzjoni, 2022, d(2022, 12, 8), d(2022, 12, 8)},
+
+		{JumIrRepubblika, 2015, d(2015, 12, 13), d(2015, 12, 13)},
+		{JumIrRepubblika, 2020, d(2020, 12, 13), d(2020, 12, 13)},
+		{JumIrRepubblika, 2022, d(2022, 12, 13), d(2022, 12, 13)},
+
+		{IlMilied, 2015, d(2015, 12, 25), d(2015, 12, 25)},
+		{IlMilied, 2020, d(2020, 12, 25), d(2020, 12, 25)},
+		{IlMilied, 2022, d(2022, 12, 25), d(2022, 12, 25)},
+	}
+
+	for _, test := range tests {
+		gotAct, gotObs := test.h.Calc(test.y)
+		if !gotAct.Equal(test.wantAct) {
+			t.Errorf("%s %d: got actual: %s, want: %s", test.h.Name, test.y, gotAct.String(), test.wantAct.String())
+		}
+		if !gotObs.Equal(test.wantObs) {
+			t.Errorf("%s %d: got observed: %s, want: %s", test.h.Name, test.y, gotObs.String(), test.wantObs.String())
+		}
+	}
+}


### PR DESCRIPTION
For our microservice we are missing the holidays for Malta.
This pull request adds the missing Maltese holidays following the existing style.

sources:

1. https://dier.gov.mt/en/employment-conditions/national%20and%20public%20holidays/pages/national-and-public-holidays.aspx?utm_source=chatgpt.com
2. https://www.officeholidays.com/countries/malta/2024
3. https://en.wikipedia.org/wiki/Public_holidays_in_Malta

please let me know if anything is not up to standard.