### PR TITLE
feat: Add holidays for Hungary

### DIFF
--- a/v2/hu/hu_holidays.go
+++ b/v2/hu/hu_holidays.go
@@ -1,0 +1,85 @@
+// (c) Rick Arnold. Licensed under the BSD license (see LICENSE).
+
+// Package hu provides holiday definitions for Hungary.
+package hu
+
+import (
+	"time"
+
+	"github.com/rickar/cal/v2"
+	"github.com/rickar/cal/v2/aa"
+)
+
+var (
+	// Ujev represents New Year's Day on 1-Jan
+	Ujev = aa.NewYear.Clone(&cal.Holiday{Name: "Újév", Type: cal.ObservancePublic})
+
+	// NemzetiUnnepMarcius represents Revolution Day on 15-Mar
+	NemzetiUnnepMarcius = &cal.Holiday{
+		Name:  "Nemzeti ünnep",
+		Type:  cal.ObservancePublic,
+		Month: time.March,
+		Day:   15,
+		Func:  cal.CalcDayOfMonth,
+	}
+
+	// Nagypentek represents Good Friday (movable, Friday before Easter Sunday)
+	Nagypentek = aa.GoodFriday.Clone(&cal.Holiday{Name: "Nagypéntek", Type: cal.ObservancePublic})
+
+	// HusvetHetfo represents Easter Monday (movable, Monday after Easter Sunday)
+	HusvetHetfo = aa.EasterMonday.Clone(&cal.Holiday{Name: "Húsvéthétfő", Type: cal.ObservancePublic})
+
+	// AmunkaUnnepe represents Labour Day on 1-May
+	AmunkaUnnepe = aa.WorkersDay.Clone(&cal.Holiday{Name: "A munka ünnepe", Type: cal.ObservancePublic})
+
+	// PunkosdHetfo represents Whit Monday (movable, Monday after Pentecost)
+	PunkosdHetfo = aa.PentecostMonday.Clone(&cal.Holiday{Name: "Pünkösdhétfő", Type: cal.ObservancePublic})
+
+	// SzentIstvanUnnepe represents State Foundation Day on 20-Aug
+	SzentIstvanUnnepe = &cal.Holiday{
+		Name:  "Az államalapítás ünnepe",
+		Type:  cal.ObservancePublic,
+		Month: time.August,
+		Day:   20,
+		Func:  cal.CalcDayOfMonth,
+	}
+
+	// NemzetiUnnepOkt represents Republic Day on 23-Oct
+	NemzetiUnnepOkt = &cal.Holiday{
+		Name:  "Nemzeti ünnep",
+		Type:  cal.ObservancePublic,
+		Month: time.October,
+		Day:   23,
+		Func:  cal.CalcDayOfMonth,
+	}
+
+	// Mindenszentek represents All Saints' Day on 1-Nov
+	Mindenszentek = aa.AllSaintsDay.Clone(&cal.Holiday{Name: "Mindenszentek", Type: cal.ObservancePublic})
+
+	// Karacsony represents Christmas Day on 25-Dec
+	Karacsony = aa.ChristmasDay.Clone(&cal.Holiday{Name: "Karácsony", Type: cal.ObservancePublic})
+
+	// KaracsonyMasnapja represents Second Day of Christmas on 26-Dec
+	KaracsonyMasnapja = &cal.Holiday{
+		Name:  "Karácsony másnapja",
+		Type:  cal.ObservancePublic,
+		Month: time.December,
+		Day:   26,
+		Func:  cal.CalcDayOfMonth,
+	}
+
+	// Holidays provides a list of the standard national holidays
+	Holidays = []*cal.Holiday{
+		Ujev,
+		NemzetiUnnepMarcius,
+		Nagypentek,
+		HusvetHetfo,
+		AmunkaUnnepe,
+		PunkosdHetfo,
+		SzentIstvanUnnepe,
+		NemzetiUnnepOkt,
+		Mindenszentek,
+		Karacsony,
+		KaracsonyMasnapja,
+	}
+)

--- a/v2/hu/hu_holidays_test.go
+++ b/v2/hu/hu_holidays_test.go
@@ -1,0 +1,77 @@
+// (c) Rick Arnold. Licensed under the BSD license (see LICENSE).
+
+package hu
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rickar/cal/v2"
+)
+
+func d(y, m, d int) time.Time {
+	return time.Date(y, time.Month(m), d, 0, 0, 0, 0, cal.DefaultLoc)
+}
+
+func TestHolidays(t *testing.T) {
+	tests := []struct {
+		h       *cal.Holiday
+		y       int
+		wantAct time.Time
+		wantObs time.Time
+	}{
+		{Ujev, 2024, d(2024, 1, 1), d(2024, 1, 1)},
+		{Ujev, 2025, d(2025, 1, 1), d(2025, 1, 1)},
+		{Ujev, 2026, d(2026, 1, 1), d(2026, 1, 1)},
+
+		{NemzetiUnnepMarcius, 2024, d(2024, 3, 15), d(2024, 3, 15)},
+		{NemzetiUnnepMarcius, 2025, d(2025, 3, 15), d(2025, 3, 15)},
+		{NemzetiUnnepMarcius, 2026, d(2026, 3, 15), d(2026, 3, 15)},
+
+		{Nagypentek, 2024, d(2024, 3, 29), d(2024, 3, 29)},
+		{Nagypentek, 2025, d(2025, 4, 18), d(2025, 4, 18)},
+		{Nagypentek, 2026, d(2026, 4, 3), d(2026, 4, 3)},
+
+		{HusvetHetfo, 2024, d(2024, 4, 1), d(2024, 4, 1)},
+		{HusvetHetfo, 2025, d(2025, 4, 21), d(2025, 4, 21)},
+		{HusvetHetfo, 2026, d(2026, 4, 6), d(2026, 4, 6)},
+
+		{AmunkaUnnepe, 2024, d(2024, 5, 1), d(2024, 5, 1)},
+		{AmunkaUnnepe, 2025, d(2025, 5, 1), d(2025, 5, 1)},
+		{AmunkaUnnepe, 2026, d(2026, 5, 1), d(2026, 5, 1)},
+
+		{PunkosdHetfo, 2024, d(2024, 5, 20), d(2024, 5, 20)},
+		{PunkosdHetfo, 2025, d(2025, 6, 9), d(2025, 6, 9)},
+		{PunkosdHetfo, 2026, d(2026, 5, 25), d(2026, 5, 25)},
+
+		{SzentIstvanUnnepe, 2024, d(2024, 8, 20), d(2024, 8, 20)},
+		{SzentIstvanUnnepe, 2025, d(2025, 8, 20), d(2025, 8, 20)},
+		{SzentIstvanUnnepe, 2026, d(2026, 8, 20), d(2026, 8, 20)},
+
+		{NemzetiUnnepOkt, 2024, d(2024, 10, 23), d(2024, 10, 23)},
+		{NemzetiUnnepOkt, 2025, d(2025, 10, 23), d(2025, 10, 23)},
+		{NemzetiUnnepOkt, 2026, d(2026, 10, 23), d(2026, 10, 23)},
+
+		{Mindenszentek, 2024, d(2024, 11, 1), d(2024, 11, 1)},
+		{Mindenszentek, 2025, d(2025, 11, 1), d(2025, 11, 1)},
+		{Mindenszentek, 2026, d(2026, 11, 1), d(2026, 11, 1)},
+
+		{Karacsony, 2024, d(2024, 12, 25), d(2024, 12, 25)},
+		{Karacsony, 2025, d(2025, 12, 25), d(2025, 12, 25)},
+		{Karacsony, 2026, d(2026, 12, 25), d(2026, 12, 25)},
+
+		{KaracsonyMasnapja, 2024, d(2024, 12, 26), d(2024, 12, 26)},
+		{KaracsonyMasnapja, 2025, d(2025, 12, 26), d(2025, 12, 26)},
+		{KaracsonyMasnapja, 2026, d(2026, 12, 26), d(2026, 12, 26)},
+	}
+
+	for _, test := range tests {
+		gotAct, gotObs := test.h.Calc(test.y)
+		if !gotAct.Equal(test.wantAct) {
+			t.Errorf("%s %d: got actual: %s, want: %s", test.h.Name, test.y, gotAct.String(), test.wantAct.String())
+		}
+		if !gotObs.Equal(test.wantObs) {
+			t.Errorf("%s %d: got observed: %s, want: %s", test.h.Name, test.y, gotObs.String(), test.wantObs.String())
+		}
+	}
+}


### PR DESCRIPTION
For our microservice we are missing the holidays for Hungary.
This pull request adds the missing Hungarian holidays following the existing style.

sources:

1. https://www.officeholidays.com/countries/hungary/2024
2. https://en.wikipedia.org/wiki/Public_holidays_in_Hungary
3. https://iszlamabad.mfa.gov.hu/hun/page/public-holidays-of-hungary-for-2024
4. https://www.qppstudio.net/publicholidays2024/hungary.htm

please let me know if anything is not up to standard.