### PR TITLE
feat: Add holidays for Estonia

### DIFF
--- a/v2/ee/ee_holidays.go
+++ b/v2/ee/ee_holidays.go
@@ -1,0 +1,95 @@
+// (c) Rick Arnold. Licensed under the BSD license (see LICENSE).
+
+// Package et provides holiday definitions for Estonia.
+package ee
+
+import (
+	"time"
+
+	"github.com/rickar/cal/v2"
+	"github.com/rickar/cal/v2/aa"
+)
+
+var (
+	// Uusaasta represents New Year's Day on 1-Jan
+	Uusaasta = aa.NewYear.Clone(&cal.Holiday{Name: "Uusaasta", Type: cal.ObservancePublic})
+
+	// Iseseisvuspaev represents Independence Day on 24-Feb
+	Iseseisvuspaev = &cal.Holiday{
+		Name:  "Iseseisvuspäev",
+		Type:  cal.ObservancePublic,
+		Month: time.February,
+		Day:   24,
+		Func:  cal.CalcDayOfMonth,
+	}
+
+	// SuurReede represents Good Friday (movable, Friday before Easter Sunday)
+	SuurReede = aa.GoodFriday.Clone(&cal.Holiday{Name: "Suur Reede", Type: cal.ObservancePublic})
+
+	// Ulestousmispuhade represents Easter Sunday (movable)
+	Ulestousmispuhade = aa.Easter.Clone(&cal.Holiday{Name: "Ülestõusmispühade 1. püha", Type: cal.ObservancePublic})
+
+	// Kevadpuha represents Spring Day on 1-May
+	Kevadpuha = aa.WorkersDay.Clone(&cal.Holiday{Name: "Kevadpüha", Type: cal.ObservancePublic})
+
+	// Nelipuha represents Pentecost (movable, 49 days after Easter Sunday)
+	Nelipuha = aa.Pentecost.Clone(&cal.Holiday{Name: "Nelipühade 1. püha", Type: cal.ObservancePublic})
+
+	// Voidupuha represents Victory Day on 23-Jun
+	Voidupuha = &cal.Holiday{
+		Name:  "Võidupüha",
+		Type:  cal.ObservancePublic,
+		Month: time.June,
+		Day:   23,
+		Func:  cal.CalcDayOfMonth,
+	}
+
+	// Jaanipaev represents Midsummer Day on 24-Jun
+	Jaanipaev = &cal.Holiday{
+		Name:  "Jaanipäev",
+		Type:  cal.ObservancePublic,
+		Month: time.June,
+		Day:   24,
+		Func:  cal.CalcDayOfMonth,
+	}
+
+	// Taasiseseisvuspaev represents Day of Restoration of Independence on 20-Aug
+	Taasiseseisvuspaev = &cal.Holiday{
+		Name:  "Taasiseseisvumispäev",
+		Type:  cal.ObservancePublic,
+		Month: time.August,
+		Day:   20,
+		Func:  cal.CalcDayOfMonth,
+	}
+
+	// Joululaupaev represents Christmas Eve on 24-Dec
+	Joululaupaev = &cal.Holiday{
+		Name:  "Jõululaupäev",
+		Type:  cal.ObservancePublic,
+		Month: time.December,
+		Day:   24,
+		Func:  cal.CalcDayOfMonth,
+	}
+
+	// EsimeneJoulupuha represents Christmas Day on 25-Dec
+	EsimeneJoulupuha = aa.ChristmasDay.Clone(&cal.Holiday{Name: "Esimene jõulupüha", Type: cal.ObservancePublic})
+
+	// TeineJoulupuha represents Boxing Day (Second Day of Christmas) on 26-Dec
+	TeineJoulupuha = aa.ChristmasDay2.Clone(&cal.Holiday{Name: "Teine jõulupüha", Type: cal.ObservancePublic})
+
+	// Holidays provides a list of the standard national holidays
+	Holidays = []*cal.Holiday{
+		Uusaasta,
+		Iseseisvuspaev,
+		SuurReede,
+		Ulestousmispuhade,
+		Kevadpuha,
+		Nelipuha,
+		Voidupuha,
+		Jaanipaev,
+		Taasiseseisvuspaev,
+		Joululaupaev,
+		EsimeneJoulupuha,
+		TeineJoulupuha,
+	}
+)

--- a/v2/ee/ee_holidays.go
+++ b/v2/ee/ee_holidays.go
@@ -1,6 +1,6 @@
 // (c) Rick Arnold. Licensed under the BSD license (see LICENSE).
 
-// Package et provides holiday definitions for Estonia.
+// Package ee provides holiday definitions for Estonia.
 package ee
 
 import (

--- a/v2/ee/ee_holidays_test.go
+++ b/v2/ee/ee_holidays_test.go
@@ -1,0 +1,81 @@
+// (c) Rick Arnold. Licensed under the BSD license (see LICENSE).
+
+package ee
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rickar/cal/v2"
+)
+
+func d(y, m, d int) time.Time {
+	return time.Date(y, time.Month(m), d, 0, 0, 0, 0, cal.DefaultLoc)
+}
+
+func TestHolidays(t *testing.T) {
+	tests := []struct {
+		h       *cal.Holiday
+		y       int
+		wantAct time.Time
+		wantObs time.Time
+	}{
+		{Uusaasta, 2024, d(2024, 1, 1), d(2024, 1, 1)},
+		{Uusaasta, 2025, d(2025, 1, 1), d(2025, 1, 1)},
+		{Uusaasta, 2026, d(2026, 1, 1), d(2026, 1, 1)},
+
+		{Iseseisvuspaev, 2024, d(2024, 2, 24), d(2024, 2, 24)},
+		{Iseseisvuspaev, 2025, d(2025, 2, 24), d(2025, 2, 24)},
+		{Iseseisvuspaev, 2026, d(2026, 2, 24), d(2026, 2, 24)},
+
+		{SuurReede, 2024, d(2024, 3, 29), d(2024, 3, 29)},
+		{SuurReede, 2025, d(2025, 4, 18), d(2025, 4, 18)},
+		{SuurReede, 2026, d(2026, 4, 3), d(2026, 4, 3)},
+
+		{Ulestousmispuhade, 2024, d(2024, 3, 31), d(2024, 3, 31)},
+		{Ulestousmispuhade, 2025, d(2025, 4, 20), d(2025, 4, 20)},
+		{Ulestousmispuhade, 2026, d(2026, 4, 5), d(2026, 4, 5)},
+
+		{Kevadpuha, 2024, d(2024, 5, 1), d(2024, 5, 1)},
+		{Kevadpuha, 2025, d(2025, 5, 1), d(2025, 5, 1)},
+		{Kevadpuha, 2026, d(2026, 5, 1), d(2026, 5, 1)},
+
+		{Nelipuha, 2024, d(2024, 5, 19), d(2024, 5, 19)},
+		{Nelipuha, 2025, d(2025, 6, 8), d(2025, 6, 8)},
+		{Nelipuha, 2026, d(2026, 5, 24), d(2026, 5, 24)},
+
+		{Voidupuha, 2024, d(2024, 6, 23), d(2024, 6, 23)},
+		{Voidupuha, 2025, d(2025, 6, 23), d(2025, 6, 23)},
+		{Voidupuha, 2026, d(2026, 6, 23), d(2026, 6, 23)},
+
+		{Jaanipaev, 2024, d(2024, 6, 24), d(2024, 6, 24)},
+		{Jaanipaev, 2025, d(2025, 6, 24), d(2025, 6, 24)},
+		{Jaanipaev, 2026, d(2026, 6, 24), d(2026, 6, 24)},
+
+		{Taasiseseisvuspaev, 2024, d(2024, 8, 20), d(2024, 8, 20)},
+		{Taasiseseisvuspaev, 2025, d(2025, 8, 20), d(2025, 8, 20)},
+		{Taasiseseisvuspaev, 2026, d(2026, 8, 20), d(2026, 8, 20)},
+
+		{Joululaupaev, 2024, d(2024, 12, 24), d(2024, 12, 24)},
+		{Joululaupaev, 2025, d(2025, 12, 24), d(2025, 12, 24)},
+		{Joululaupaev, 2026, d(2026, 12, 24), d(2026, 12, 24)},
+
+		{EsimeneJoulupuha, 2024, d(2024, 12, 25), d(2024, 12, 25)},
+		{EsimeneJoulupuha, 2025, d(2025, 12, 25), d(2025, 12, 25)},
+		{EsimeneJoulupuha, 2026, d(2026, 12, 25), d(2026, 12, 25)},
+
+		{TeineJoulupuha, 2024, d(2024, 12, 26), d(2024, 12, 26)},
+		{TeineJoulupuha, 2025, d(2025, 12, 26), d(2025, 12, 26)},
+		{TeineJoulupuha, 2026, d(2026, 12, 26), d(2026, 12, 26)},
+	}
+
+	for _, test := range tests {
+		gotAct, gotObs := test.h.Calc(test.y)
+		if !gotAct.Equal(test.wantAct) {
+			t.Errorf("%s %d: got actual: %s, want: %s", test.h.Name, test.y, gotAct.String(), test.wantAct.String())
+		}
+		if !gotObs.Equal(test.wantObs) {
+			t.Errorf("%s %d: got observed: %s, want: %s", test.h.Name, test.y, gotObs.String(), test.wantObs.String())
+		}
+	}
+}


### PR DESCRIPTION
For our microservice we are missing the holidays for Estonia.
This pull request adds the missing Estonian holidays following the existing style.

sources:

1. https://www.officeholidays.com/countries/estonia/2024
2. https://www.qppstudio.net/publicholidays2024/estonia.htm
3. https://www.eesti.ee/eraisik/en/artikkel/republic-of-estonia/republic-of-estonia/national-public-and-school-holidays

please let me know if anything is not up to standard.