### PR TITLE
fix: Handle Emperor's Birthday in 2019 special case

### DIFF
--- a/v2/jp/jp_holidays.go
+++ b/v2/jp/jp_holidays.go
@@ -4,10 +4,11 @@
 package jp
 
 import (
-	"github.com/rickar/cal/v2"
-	"github.com/rickar/cal/v2/aa"
 	"math"
 	"time"
+
+	"github.com/rickar/cal/v2"
+	"github.com/rickar/cal/v2/aa"
 )
 
 var (
@@ -47,16 +48,19 @@ var (
 		Day:      23,
 		Observed: weekendAlt,
 		Func: func(h *cal.Holiday, year int) time.Time {
-			if year <= 2019 {
+			switch {
+			case year <= 2018:
 				// Emperor Akihito abdicated in 2019.
 				holiday := *h
 				holiday.Month = time.December
 				holiday.Day = 23
-
 				return cal.CalcDayOfMonth(&holiday, year)
+			case year == 2019:
+				// There is no official Emperor's Birthday holiday in 2019 due to the transition
+				return time.Time{}
+			default:
+				return cal.CalcDayOfMonth(h, year)
 			}
-
-			return cal.CalcDayOfMonth(h, year)
 		},
 	}
 

--- a/v2/jp/jp_holidays_test.go
+++ b/v2/jp/jp_holidays_test.go
@@ -3,9 +3,10 @@
 package jp
 
 import (
-	"github.com/rickar/cal/v2"
 	"testing"
 	"time"
+
+	"github.com/rickar/cal/v2"
 )
 
 func d(y, m, d int) time.Time {
@@ -50,7 +51,7 @@ func TestHolidays(t *testing.T) {
 		{TheEmperorsBirthday, 2016, d(2016, 12, 23), d(2016, 12, 23)},
 		{TheEmperorsBirthday, 2017, d(2017, 12, 23), d(2017, 12, 23)},
 		{TheEmperorsBirthday, 2018, d(2018, 12, 23), d(2018, 12, 24)},
-		{TheEmperorsBirthday, 2019, d(2019, 12, 23), d(2019, 12, 23)},
+		{TheEmperorsBirthday, 2019, time.Time{}, time.Time{}},
 		{TheEmperorsBirthday, 2020, d(2020, 2, 23), d(2020, 2, 24)},
 		{TheEmperorsBirthday, 2021, d(2021, 2, 23), d(2021, 2, 23)},
 		{TheEmperorsBirthday, 2022, d(2022, 2, 23), d(2022, 2, 23)},


### PR DESCRIPTION
## Fix: Handle Emperor's Birthday Correctly in 2019

This pull request addresses the issue with the handling of the Emperor's Birthday holiday in 2019. As outlined in the [Japanese National Holiday](https://www8.cao.go.jp/chosei/shukujitsu/gaiyou.html), the Emperor's Birthday was not officially observed as a national holiday in 2019 due to the imperial transition. 

The changes in this PR ensure that the `TheEmperorsBirthday` holiday is correctly handled for the year 2019, where no holiday is observed. For years prior to 2019, the holiday is set to December 23rd, and from 2020 onwards, it is set to February 23rd as per the current law.

This PR helps maintain accurate and up-to-date holiday information in the calendar library, and ensures that the 2019 special case is properly accounted for.