### PR TITLE
feat: remove 1st september holiday

### DIFF
--- a/v2/sk/sk_holidays.go
+++ b/v2/sk/sk_holidays.go
@@ -56,11 +56,12 @@ var (
 
 	// Constitution represents Constitution Day on 1-Sep
 	Constitution = &cal.Holiday{
-		Name:  "Deň Ústavy Slovenskej republiky",
-		Type:  cal.ObservancePublic,
-		Month: time.September,
-		Day:   1,
-		Func:  cal.CalcDayOfMonth,
+		Name:    "Deň Ústavy Slovenskej republiky",
+		Type:    cal.ObservancePublic,
+		Month:   time.September,
+		Day:     1,
+		Func:    cal.CalcDayOfMonth,
+		EndYear: 2024,
 	}
 
 	// LadyOfSorrows represents Day of Our Lady of the Seven Sorrows on 15-Sep


### PR DESCRIPTION
Cause Slovakian government cancelled one of holidays (1st september) we need to mirror it in holiday list

slovakian source:
https://www.ip.gov.sk/1-september-uz-nie-je-dnom-pracovneho-pokoja/