### PR TITLE
fix(it): add San Francesco d’Assisi starting 2026

### DIFF
--- a/v2/it/it_holidays.go
+++ b/v2/it/it_holidays.go
@@ -44,6 +44,16 @@ var (
 	// Assunzione represents Assumption of Mary on 15-Aug
 	Assunzione = aa.AssumptionOfMary.Clone(&cal.Holiday{Name: "Assunzione", Type: cal.ObservancePublic})
 
+	// San Francesco d’Assisi represents Saint Francis of Assisi's Day on 4-Oct
+	SanFrancescoDAssisi = &cal.Holiday{
+		Name:      "San Francesco d'Assisi",
+		Type:      cal.ObservancePublic,
+		Month:     time.October,
+		Day:       4,
+		Func:      cal.CalcDayOfMonth,
+		StartYear: 2026,
+	}
+
 	// TuttiISanti represents All Saints' Day on 1-Nov
 	TuttiISanti = aa.AllSaintsDay.Clone(&cal.Holiday{Name: "Tutti i santi", Type: cal.ObservancePublic})
 
@@ -65,6 +75,7 @@ var (
 		FestaDelLavoro,
 		FestaDellaRepubblica,
 		Assunzione,
+		SanFrancescoDAssisi,
 		TuttiISanti,
 		Immacolata,
 		Natale,


### PR DESCRIPTION
The Italian public holidays are missing October 4th, which was reinstated as a national holiday in 2025. The first public observance is in 2026 (on a Sunday).

Disclaimer: I live in France, not in Italy, but I still wanted to open this PR as I would need it anyway in 2027.

Sources:
- https://www.romereports.com/en/2025/10/02/italy-restores-the-national-holiday-of-saint-francis-of-assisi-starting-in-2026/
- https://www.theguardian.com/world/2025/sep/24/italy-to-revive-national-holiday-in-honour-of-patron-saint-francis-of-assisi