### PR TITLE
Floor the modified Julian day number instead of truncating

### DIFF
--- a/v2/cal_funcs.go
+++ b/v2/cal_funcs.go
@@ -3,6 +3,7 @@
 package cal
 
 import (
+	"math"
 	"time"
 )
 
@@ -151,7 +152,7 @@ func ModifiedJulianDayNumber(t time.Time) int {
 	// algorithm from http://www.tondering.dk/claus/cal/julperiod.php#formula
 	mjd := JulianDate(t)
 	mjd -= 2400000.5
-	return int(mjd)
+	return int(math.Floor(mjd))
 }
 
 // JulianDate reports the Julian Date (which includes time as a fraction) for t.

--- a/v2/cal_funcs_test.go
+++ b/v2/cal_funcs_test.go
@@ -243,6 +243,10 @@ func TestModifiedJulianDayNumber(t *testing.T) {
 		t    time.Time
 		want int
 	}{
+		{time.Date(1600, 1, 1, 12, 0, 0, 0, time.UTC), -94553},
+		{time.Date(1858, 11, 16, 0, 0, 0, 0, time.UTC), -1},
+		{time.Date(1858, 11, 16, 12, 0, 0, 0, time.UTC), -1},
+		{time.Date(1858, 11, 17, 0, 0, 0, 0, time.UTC), 0},
 		{time.Date(1980, 1, 1, 0, 0, 0, 0, time.UTC), 44239},
 		{time.Date(1980, 1, 1, 12, 0, 0, 0, time.UTC), 44239},
 		{time.Date(2000, 1, 1, 15, 0, 0, 0, time.UTC), 51544},


### PR DESCRIPTION
`ModifiedJulianDayNumber` computes a float MJD and returns `int(mjd)`. Go truncates toward zero, so every instant before the MJD epoch 1858-11-17T00:00Z comes back one day too high.

The clearest way to see it is to walk consecutive days across the epoch:

```
1858-11-14 12:00Z  MJDN=-2
1858-11-15 12:00Z  MJDN=-1
1858-11-16 12:00Z  MJDN=0     <-
1858-11-17 12:00Z  MJDN=0     <-
1858-11-18 12:00Z  MJDN=1
```

Two distinct calendar days report the same day number, and the day numbers on either side of the epoch are not contiguous.

The library already has the right answer elsewhere. `ModifiedJulianDate` returns `-94552.5` for 1600-01-01 12:00Z while `ModifiedJulianDayNumber` returns `-94552`; the floor is `-94553`. `JulianDayNumber` is unaffected because it uses exact integer arithmetic rather than a float cast, so the two day-number functions disagree about how to handle their negative range.

I checked against an independent Meeus-algorithm implementation for 1600-01-01 12:00Z: JD 2305448.0, MJD -94552.5, MJDN -94553. That agrees with this package's own `ModifiedJulianDate` and with the floor.

## The fix

`int(mjd)` becomes `int(math.Floor(mjd))`, plus the `math` import. Four rows added to the existing `TestModifiedJulianDayNumber` table.

## Behaviour change

Yes, for dates before 1858-11-17 only. **No existing test row changes** -- all five pre-existing rows are 1980-2016, where floor and truncation agree.

## Verification

CI gates as the workflow runs them (Format / Build / Test): `gofmt -s -l .` reports 0 files, `go build ./...` clean, `go test -count=1 ./...` passes 51/51 packages.

I checked the boundary from both sides rather than only confirming the new rows go green:

- truncate again -- `got: -94552; want: -94553` and `got: 0; want: -1`
- `floor(mjd) - 1` -- fails all five pre-existing positive rows
- the naive `if mjd < 0 { trunc(mjd) - 1 }` patch -- fails `got: -2; want: -1` on 1858-11-16 00:00Z, which is why that exact-integer row is in the table

I also swept 255,670 days from 1500-01-01 to 2200-01-01 checking that MJDN at 00:00Z and 12:00Z agree and increment by exactly 1 per day: zero violations. Floor does not misfire at exact-integer MJD values, which was my main worry about the change.

One note on scope: `go vet` reports two `sync.Once` copies in `cal_test.go:25,28`. Those are pre-existing (confirmed by stashing and re-running at master) and CI does not run vet, so I left them alone.

---

Disclosure: AI-assisted. I found and prepared this with an AI assistant, and I ran and verified everything above myself.
